### PR TITLE
feat: migrate away from UniverseLib

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf

--- a/Game/GameData.cs
+++ b/Game/GameData.cs
@@ -86,14 +86,15 @@ public static class GameData {
   /// </summary>
   public static class Relics {
     private static readonly Lazy<List<Sprite>> LazyIcons = new(() =>
-      Names.Where(it => it != Badge.Name.Max && it != Badge.Name.None)
-        .Select(it => IconManager.Instance.GetBadgeIcon(it)).ToList()
+      Names.Select(it => IconManager.Instance.GetBadgeIcon(it)).ToList()
     );
 
     /// <summary>
     ///   A list of all the Relic names.
     /// </summary>
-    public static readonly List<Badge.Name> Names = Util.GetEnumValues<Badge.Name>();
+    public static readonly List<Badge.Name> Names = Util.GetEnumValues<Badge.Name>()
+      .Where(it => it != Badge.Name.Max && it != Badge.Name.None)
+      .ToList();
 
     /// <summary>
     ///   A list of icons for each Relic.

--- a/ItemSpawner.csproj
+++ b/ItemSpawner.csproj
@@ -20,14 +20,11 @@
         <PackageReference Include="BepInEx.Core" Version="5.*"/>
         <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*"/>
         <PackageReference Include="UnityEngine.Modules" Version="2022.3.41" IncludeAssets="compile"/>
-        <PackageReference Include="rainbowblood.UniverseLib.Mono" Version="2.*">
-            <NoWarn>NU1701</NoWarn>
-        </PackageReference>
     </ItemGroup>
 
     <Target Name="CopyOutput" AfterTargets="Build">
         <ItemGroup>
-            <OutputFiles Include="$(TargetDir)$(TargetFileName);$(TargetDir)UniverseLib*.dll"/>
+            <OutputFiles Include="$(TargetDir)$(TargetFileName)"/>
         </ItemGroup>
 
         <Copy SourceFiles="@(OutputFiles)" DestinationFolder="$(TargetDir)$(RootNamespace)" SkipUnchangedFiles="true"/>

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,7 +1,6 @@
-﻿using BepInEx;
+using BepInEx;
 using BepInEx.Logging;
 using daymxn.DHG.ItemSpawner.ui;
-using UniverseLib;
 
 namespace daymxn.DHG.ItemSpawner;
 
@@ -9,15 +8,28 @@ namespace daymxn.DHG.ItemSpawner;
 [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
 public class Plugin : BaseUnityPlugin {
   internal new static ManualLogSource Logger;
+  private bool _uiInitialized;
 
   private void Awake() {
     Logger = base.Logger;
     Logger.LogInfo($"Plugin {MyPluginInfo.PLUGIN_GUID} is loaded!");
-    Universe.Init(LateInit);
   }
 
-  public void LateInit() {
-    UIManager.InitUI();
-    Logger.LogInfo("UI loaded. Load a save file to get started.");
+  private void Update() {
+    // BepInEx plugins wake before the game's scene behaviours have necessarily
+    // completed Start(). Initializing on the first Update gives game-owned UI
+    // services, including an EventSystem, the first opportunity to come online.
+    if (!_uiInitialized) {
+      _uiInitialized = true;
+      UIManager.InitUI();
+      Logger.LogInfo("UI loaded. Load a save file to get started.");
+    }
+
+    UIManager.Update();
+  }
+
+  private void OnDestroy() {
+    UIManager.Shutdown();
+    _uiInitialized = false;
   }
 }

--- a/README.md
+++ b/README.md
@@ -57,16 +57,16 @@ don't have a `plugins` directory, you can go ahead and create one.
 > [!NOTE]
 > The navbar will show after a few seconds at the main menu, but the buttons will be disabled until you load a save.
 
+> [!IMPORTANT]
+> When upgrading from a version that bundled UniverseLib, remove the old `daymxn.DHG.ItemSpawner` plugin folder before
+> extracting the new version. UniverseLib is no longer used or included.
+
 ## [Future Work](#future-work)
 
 There's definitely a few places where I feel like this could be improved upon, or features could be added. A few of such
 cases are:
 
 - Migrate to MVVM.
-- Possibly migrate to different UI framework.
-    * UniverseLib was great for prototyping, but I've found myself fighting with it more than working on features.
-      I'm not sure what the best alternative would be (maybe even writing my own UI library), but it's worth
-      investigating in the future.
 - Add support for selecting and modifying existing items in the player's inventory.
 - Auto complete dropdown for affixes and powers.
 - Some form of affix dropdown that mirrors the game's dropdown for chaos behavior (where it shows the description and

--- a/UI/Native/DropdownBinding.cs
+++ b/UI/Native/DropdownBinding.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine.UI;
+
+namespace daymxn.DHG.ItemSpawner.ui.Native;
+
+internal readonly struct DropdownOption<T> {
+  internal DropdownOption(string label, T value) {
+    Label = label;
+    Value = value;
+  }
+
+  internal string Label { get; }
+  internal T Value { get; }
+}
+
+/// <summary>
+///   Keeps displayed dropdown indices separate from their underlying game values.
+/// </summary>
+internal sealed class DropdownBinding<T> {
+  private readonly List<T> _values = [];
+
+  internal DropdownBinding(Dropdown dropdown, Action<T> onValueChanged) {
+    Component = dropdown;
+    if (onValueChanged != null) ValueChanged += onValueChanged;
+    Component.onValueChanged.AddListener(OnIndexChanged);
+  }
+
+  internal Dropdown Component { get; }
+
+  internal bool HasValue => _values.Count > 0 && Component.value < _values.Count;
+
+  internal T Value {
+    get {
+      if (!HasValue) throw new InvalidOperationException("The dropdown has no selected value.");
+      return _values[Component.value];
+    }
+  }
+
+  internal event Action<T> ValueChanged;
+
+  internal void SetOptions(IEnumerable<DropdownOption<T>> options, T preferredValue) {
+    Component.Hide();
+    var materialized = options?.ToList() ?? [];
+    _values.Clear();
+    _values.AddRange(materialized.Select(option => option.Value));
+
+    Component.ClearOptions();
+    Component.AddOptions(materialized.Select(option => option.Label).ToList());
+    Component.interactable = _values.Count > 0;
+
+    if (_values.Count == 0) {
+      Component.SetValueWithoutNotify(0);
+      Component.RefreshShownValue();
+      return;
+    }
+
+    var selectedIndex = _values.FindIndex(value =>
+      EqualityComparer<T>.Default.Equals(value, preferredValue));
+    Component.SetValueWithoutNotify(selectedIndex >= 0 ? selectedIndex : 0);
+    Component.RefreshShownValue();
+  }
+
+  internal void Hide() {
+    Component.Hide();
+  }
+
+  private void OnIndexChanged(int index) {
+    if (index < 0 || index >= _values.Count) return;
+    ValueChanged?.Invoke(_values[index]);
+  }
+}

--- a/UI/Native/NativeDropdownOverlay.cs
+++ b/UI/Native/NativeDropdownOverlay.cs
@@ -1,0 +1,80 @@
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace daymxn.DHG.ItemSpawner.ui.Native;
+
+/// <summary>
+///   Moves Unity's generated dropdown list out of scroll views/masks while it's open.
+///   Dropdown still owns and destroys the generated list normally.
+/// </summary>
+internal sealed class NativeDropdownOverlay : MonoBehaviour {
+  private RectTransform _blocker;
+  private RectTransform _canvasRoot;
+  private Dropdown _dropdown;
+  private RectTransform _popup;
+
+  private void LateUpdate() {
+    if (!_dropdown || !_canvasRoot) {
+      _popup = null;
+      return;
+    }
+
+    if (!_popup) {
+      _popup = FindGeneratedPopup();
+      if (!_popup) {
+        _blocker = null;
+        return;
+      }
+
+      _popup.SetParent(_canvasRoot, true);
+      PromoteToTopmostCanvas(_popup.gameObject);
+    }
+
+    if (!_blocker) {
+      _blocker = FindGeneratedBlocker();
+      if (_blocker) PromoteCloseBlocker(_blocker.gameObject);
+    }
+
+    // windows may change sibling order when focused. keep the active popup above
+    // every window for as long as the dropdown owns it.
+    _popup.SetAsLastSibling();
+  }
+
+  internal void Configure(Dropdown dropdown, RectTransform canvasRoot) {
+    _dropdown = dropdown;
+    _canvasRoot = canvasRoot;
+  }
+
+  private RectTransform FindGeneratedPopup() {
+    return (from Transform child in transform
+      where child.name.StartsWith("Dropdown List")
+      select child as RectTransform).FirstOrDefault();
+  }
+
+  private RectTransform FindGeneratedBlocker() {
+    return (from Transform child in _canvasRoot
+      where child.name == "Blocker" && child.gameObject.activeInHierarchy
+      select child as RectTransform).FirstOrDefault();
+  }
+
+  private static void PromoteToTopmostCanvas(GameObject popup) {
+    var popupCanvas = popup.GetComponent<Canvas>() ?? popup.AddComponent<Canvas>();
+    popupCanvas.overrideSorting = true;
+    popupCanvas.sortingOrder = short.MaxValue;
+
+    if (!popup.GetComponent<GraphicRaycaster>()) {
+      popup.AddComponent<GraphicRaycaster>();
+    }
+  }
+
+  private static void PromoteCloseBlocker(GameObject blocker) {
+    var blockerCanvas = blocker.GetComponent<Canvas>() ?? blocker.AddComponent<Canvas>();
+    blockerCanvas.overrideSorting = true;
+    blockerCanvas.sortingOrder = short.MaxValue - 1;
+
+    if (!blocker.GetComponent<GraphicRaycaster>()) {
+      blocker.AddComponent<GraphicRaycaster>();
+    }
+  }
+}

--- a/UI/Native/NativeEventSystemBridge.cs
+++ b/UI/Native/NativeEventSystemBridge.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace daymxn.DHG.ItemSpawner.ui.Native;
+
+/// <summary>
+///   Supplies input for the mod's native uGUI only when the game has not supplied
+///   an active EventSystem of its own.
+/// </summary>
+internal sealed class NativeEventSystemBridge : MonoBehaviour {
+  private EventSystem _fallback;
+  private GameObject _fallbackRoot;
+
+  internal EventSystem Current => FindGameEventSystem() ?? EnsureFallback();
+  internal bool IsUsingFallback => _fallback && _fallback.isActiveAndEnabled;
+
+  private void Update() {
+    var gameEventSystem = FindGameEventSystem();
+    if (gameEventSystem) {
+      ReleaseFallback();
+      return;
+    }
+
+    EnsureFallback();
+  }
+
+  private void OnDestroy() {
+    ReleaseFallback();
+  }
+
+  private EventSystem EnsureFallback() {
+    if (_fallback) {
+      if (!_fallbackRoot.activeSelf) _fallbackRoot.SetActive(true);
+      return _fallback;
+    }
+
+    _fallbackRoot = new GameObject(
+      $"{MyPluginInfo.PLUGIN_GUID}.FallbackEventSystem",
+      typeof(EventSystem),
+      typeof(StandaloneInputModule)
+    );
+    DontDestroyOnLoad(_fallbackRoot);
+    _fallback = _fallbackRoot.GetComponent<EventSystem>();
+    Plugin.Logger.LogWarning(
+      "The game has no active EventSystem; ItemSpawner created a temporary native uGUI fallback.");
+    return _fallback;
+  }
+
+  private EventSystem FindGameEventSystem() {
+    return FindObjectsOfType<EventSystem>()
+      .FirstOrDefault(candidate => candidate && candidate != _fallback &&
+                                   candidate.isActiveAndEnabled);
+  }
+
+  private void ReleaseFallback() {
+    if (!_fallbackRoot) return;
+
+    // disable synchronously so there are never two active systems while Unity
+    // waits until the end of the frame to perform the actual destruction.
+    _fallbackRoot.SetActive(false);
+    Destroy(_fallbackRoot);
+    _fallbackRoot = null;
+    _fallback = null;
+    Plugin.Logger.LogInfo("ItemSpawner released its fallback EventSystem to the game.");
+  }
+}

--- a/UI/Native/NativeWindowInteraction.cs
+++ b/UI/Native/NativeWindowInteraction.cs
@@ -1,0 +1,121 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace daymxn.DHG.ItemSpawner.ui.Native;
+
+internal static class NativeWindowLayout {
+  internal static void ClampSize(RectTransform window, RectTransform parent, Vector2 minimum) {
+    var parentSize = parent.rect.size;
+    if (parentSize.x <= 1 || parentSize.y <= 1) return;
+    var maxWidth = Mathf.Max(1, parentSize.x);
+    var maxHeight = Mathf.Max(1, parentSize.y);
+    var minWidth = Mathf.Min(minimum.x, maxWidth);
+    var minHeight = Mathf.Min(minimum.y, maxHeight);
+    window.sizeDelta = new Vector2(
+      Mathf.Clamp(window.sizeDelta.x, minWidth, maxWidth),
+      Mathf.Clamp(window.sizeDelta.y, minHeight, maxHeight)
+    );
+  }
+
+  internal static void ClampToParent(RectTransform window, RectTransform parent) {
+    var parentSize = parent.rect.size;
+    if (parentSize.x <= 1 || parentSize.y <= 1) return;
+    var windowSize = window.rect.size;
+    var anchor = window.anchorMin;
+    var pivot = window.pivot;
+
+    var minX = -anchor.x * parentSize.x + pivot.x * windowSize.x;
+    var maxX = (1 - anchor.x) * parentSize.x - (1 - pivot.x) * windowSize.x;
+    var minY = -anchor.y * parentSize.y + pivot.y * windowSize.y;
+    var maxY = (1 - anchor.y) * parentSize.y - (1 - pivot.y) * windowSize.y;
+
+    var position = window.anchoredPosition;
+    position.x = minX <= maxX ? Mathf.Clamp(position.x, minX, maxX) : (minX + maxX) * 0.5f;
+    position.y = minY <= maxY ? Mathf.Clamp(position.y, minY, maxY) : (minY + maxY) * 0.5f;
+    window.anchoredPosition = position;
+  }
+}
+
+internal sealed class NativeWindowFocusHandler : MonoBehaviour, IPointerDownHandler {
+  private RectTransform _window;
+
+  internal void Configure(RectTransform window) {
+    _window = window;
+  }
+
+  public void OnPointerDown(PointerEventData eventData) {
+    if (_window) _window.SetAsLastSibling();
+  }
+}
+
+internal sealed class NativeWindowDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler,
+  IEndDragHandler {
+  private Canvas _canvas;
+  private RectTransform _parent;
+  private RectTransform _window;
+
+  internal void Configure(RectTransform window, RectTransform parent, Canvas canvas) {
+    _window = window;
+    _parent = parent;
+    _canvas = canvas;
+  }
+
+  public void OnBeginDrag(PointerEventData eventData) {
+    if (_window) _window.SetAsLastSibling();
+  }
+
+  public void OnDrag(PointerEventData eventData) {
+    if (!_window || !_parent || !_canvas) return;
+    _window.anchoredPosition += eventData.delta / Mathf.Max(0.01f, _canvas.scaleFactor);
+    NativeWindowLayout.ClampToParent(_window, _parent);
+  }
+
+  public void OnEndDrag(PointerEventData eventData) {
+    if (_window && _parent) NativeWindowLayout.ClampToParent(_window, _parent);
+  }
+}
+
+internal sealed class NativeWindowResizeHandler : MonoBehaviour, IBeginDragHandler, IDragHandler,
+  IEndDragHandler {
+  private Canvas _canvas;
+  private Vector2 _minimum;
+  private RectTransform _parent;
+  private RectTransform _window;
+
+  internal void Configure(
+    RectTransform window,
+    RectTransform parent,
+    Canvas canvas,
+    Vector2 minimum
+  ) {
+    _window = window;
+    _parent = parent;
+    _canvas = canvas;
+    _minimum = minimum;
+  }
+
+  public void OnBeginDrag(PointerEventData eventData) {
+    if (_window) _window.SetAsLastSibling();
+  }
+
+  public void OnDrag(PointerEventData eventData) {
+    if (!_window || !_parent || !_canvas) return;
+    var delta = eventData.delta / Mathf.Max(0.01f, _canvas.scaleFactor);
+    var oldSize = _window.sizeDelta;
+    _window.sizeDelta += new Vector2(delta.x, -delta.y);
+    NativeWindowLayout.ClampSize(_window, _parent, _minimum);
+
+    var actualDelta = _window.sizeDelta - oldSize;
+    _window.anchoredPosition += new Vector2(
+      _window.pivot.x * actualDelta.x,
+      -(1 - _window.pivot.y) * actualDelta.y
+    );
+    NativeWindowLayout.ClampToParent(_window, _parent);
+  }
+
+  public void OnEndDrag(PointerEventData eventData) {
+    if (!_window || !_parent) return;
+    NativeWindowLayout.ClampSize(_window, _parent, _minimum);
+    NativeWindowLayout.ClampToParent(_window, _parent);
+  }
+}

--- a/UI/Native/UIFactory.cs
+++ b/UI/Native/UIFactory.cs
@@ -1,0 +1,519 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using Object = UnityEngine.Object;
+
+namespace daymxn.DHG.ItemSpawner.ui.Native;
+
+/// <summary>
+///   Creates the small set of native uGUI controls used by the item spawners.
+/// </summary>
+internal static class UIFactory {
+  private const int DefaultFontSize = 14;
+  private static Font _defaultFont;
+  private static Sprite _whiteSprite;
+
+  private static Font DefaultFont {
+    get {
+      if (_defaultFont) return _defaultFont;
+
+      _defaultFont = Resources.GetBuiltinResource<Font>("Arial.ttf");
+      if (_defaultFont) return _defaultFont;
+
+      foreach (var font in Resources.FindObjectsOfTypeAll<Font>()) {
+        if (!font) continue;
+        _defaultFont = font;
+        Plugin.Logger?.LogWarning($"Built-in Arial was unavailable; using font '{font.name}'.");
+        break;
+      }
+
+      return _defaultFont;
+    }
+  }
+
+  private static Sprite WhiteSprite {
+    get {
+      if (_whiteSprite) return _whiteSprite;
+      var texture = new Texture2D(1, 1, TextureFormat.RGBA32, false) {
+        name = "ItemSpawner.WhiteTexture",
+        hideFlags = HideFlags.HideAndDontSave
+      };
+      texture.SetPixel(0, 0, Color.white);
+      texture.Apply();
+      _whiteSprite = Sprite.Create(texture, new Rect(0, 0, 1, 1), new Vector2(0.5f, 0.5f));
+      _whiteSprite.name = "ItemSpawner.WhiteSprite";
+      _whiteSprite.hideFlags = HideFlags.HideAndDontSave;
+      return _whiteSprite;
+    }
+  }
+
+  internal static GameObject CreateCanvasRoot(string name) {
+    var root = new GameObject(name, typeof(RectTransform), typeof(Canvas), typeof(CanvasScaler),
+      typeof(GraphicRaycaster));
+    var uiLayer = LayerMask.NameToLayer("UI");
+    if (uiLayer >= 0) root.layer = uiLayer;
+
+    var canvas = root.GetComponent<Canvas>();
+    canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+    canvas.overrideSorting = true;
+    canvas.sortingOrder = 32_760;
+
+    var scaler = root.GetComponent<CanvasScaler>();
+    // UniverseLib used pixel-sized windows. ConstantPixelSize preserves those
+    // dimensions instead of enlarging every control on resolutions above 1080p.
+    scaler.uiScaleMode = CanvasScaler.ScaleMode.ConstantPixelSize;
+    scaler.scaleFactor = 1;
+    scaler.referencePixelsPerUnit = 100;
+
+    var rect = root.GetComponent<RectTransform>();
+    Stretch(rect);
+    Object.DontDestroyOnLoad(root);
+    return root;
+  }
+
+  internal static GameObject CreateUIObject(string name, GameObject parent) {
+    var child = new GameObject(name, typeof(RectTransform)) {
+      layer = parent.layer
+    };
+    child.transform.SetParent(parent.transform, false);
+    return child;
+  }
+
+  internal static Image AddImage(GameObject target, Color color, bool raycastTarget = true) {
+    var image = target.GetComponent<Image>() ?? target.AddComponent<Image>();
+    image.sprite = WhiteSprite;
+    image.type = Image.Type.Simple;
+    image.color = color;
+    image.raycastTarget = raycastTarget;
+    return image;
+  }
+
+  internal static Text CreateLabel(
+    GameObject parent,
+    string name,
+    string text,
+    TextAnchor alignment = TextAnchor.MiddleLeft,
+    Color? color = null,
+    int fontSize = DefaultFontSize
+  ) {
+    var root = CreateUIObject(name, parent);
+    var label = root.AddComponent<Text>();
+    label.font = DefaultFont;
+    label.fontSize = fontSize;
+    label.text = text;
+    label.alignment = alignment;
+    label.color = color ?? Theme.TextColor;
+    label.raycastTarget = false;
+    label.horizontalOverflow = HorizontalWrapMode.Wrap;
+    label.verticalOverflow = VerticalWrapMode.Truncate;
+    return label;
+  }
+
+  internal static Button CreateButton(
+    GameObject parent,
+    string name,
+    string text,
+    Color? color = null
+  ) {
+    var root = CreateUIObject(name, parent);
+    var image = AddImage(root, Color.white);
+    var button = root.AddComponent<Button>();
+    button.targetGraphic = image;
+    button.colors = ColorBlockFor(color ?? Theme.ControlColor);
+
+    var label = CreateLabel(root, "Label", text, TextAnchor.MiddleCenter);
+    Stretch(label.rectTransform);
+    return button;
+  }
+
+  private static GameObject CreateDropdown(
+    GameObject parent,
+    string name,
+    out Dropdown dropdown,
+    string placeholder,
+    int fontSize,
+    Action<int> onChanged,
+    IEnumerable<string> options
+  ) {
+    var root = CreateUIObject(name, parent);
+    var rootImage = AddImage(root, Color.white);
+    dropdown = root.AddComponent<Dropdown>();
+    dropdown.targetGraphic = rootImage;
+    dropdown.colors = ColorBlockFor(Theme.ControlColor);
+
+    var caption = CreateLabel(root, "Label", placeholder, TextAnchor.MiddleLeft,
+      Theme.TextColor, fontSize);
+    caption.rectTransform.anchorMin = Vector2.zero;
+    caption.rectTransform.anchorMax = Vector2.one;
+    caption.rectTransform.offsetMin = new Vector2(10, 2);
+    caption.rectTransform.offsetMax = new Vector2(-28, -2);
+
+    var arrow = CreateLabel(root, "Arrow", "▼", TextAnchor.MiddleCenter,
+      Theme.TextColor, fontSize);
+    arrow.rectTransform.anchorMin = new Vector2(1, 0);
+    arrow.rectTransform.anchorMax = Vector2.one;
+    arrow.rectTransform.pivot = new Vector2(1, 0.5f);
+    arrow.rectTransform.sizeDelta = new Vector2(24, 0);
+    arrow.rectTransform.anchoredPosition = Vector2.zero;
+
+    var template = CreateUIObject("Template", root);
+    var templateRect = template.GetComponent<RectTransform>();
+    templateRect.anchorMin = new Vector2(0, 0);
+    templateRect.anchorMax = new Vector2(1, 0);
+    templateRect.pivot = new Vector2(0.5f, 1);
+    templateRect.anchoredPosition = new Vector2(0, -2);
+    templateRect.sizeDelta = new Vector2(0, 180);
+    AddImage(template, Theme.PanelColor);
+
+    var viewport = CreateUIObject("Viewport", template);
+    var viewportRect = viewport.GetComponent<RectTransform>();
+    Stretch(viewportRect);
+    viewportRect.offsetMax = new Vector2(-14, 0);
+    AddImage(viewport, Theme.PanelColor);
+    viewport.AddComponent<Mask>().showMaskGraphic = false;
+
+    var content = CreateUIObject("Content", viewport);
+    var contentRect = content.GetComponent<RectTransform>();
+    contentRect.anchorMin = new Vector2(0, 1);
+    contentRect.anchorMax = new Vector2(1, 1);
+    contentRect.pivot = new Vector2(0.5f, 1);
+    contentRect.anchoredPosition = Vector2.zero;
+    contentRect.sizeDelta = Vector2.zero;
+    var contentLayout = content.AddComponent<VerticalLayoutGroup>();
+    contentLayout.childControlHeight = true;
+    contentLayout.childControlWidth = true;
+    contentLayout.childForceExpandHeight = false;
+    contentLayout.childForceExpandWidth = true;
+    contentLayout.spacing = 1;
+    content.AddComponent<ContentSizeFitter>().verticalFit =
+      ContentSizeFitter.FitMode.PreferredSize;
+
+    var item = CreateUIObject("Item", content);
+    AddImage(item, Theme.ControlColor);
+    SetLayoutElement(item, minHeight: 26, flexibleWidth: 1);
+    var itemToggle = item.AddComponent<Toggle>();
+    itemToggle.targetGraphic = item.GetComponent<Image>();
+
+    var checkmarkRoot = CreateUIObject("Item Checkmark", item);
+    var checkmarkRect = checkmarkRoot.GetComponent<RectTransform>();
+    checkmarkRect.anchorMin = new Vector2(0, 0.5f);
+    checkmarkRect.anchorMax = new Vector2(0, 0.5f);
+    checkmarkRect.pivot = new Vector2(0, 0.5f);
+    checkmarkRect.anchoredPosition = new Vector2(7, 0);
+    checkmarkRect.sizeDelta = new Vector2(8, 8);
+    var checkmark = AddImage(checkmarkRoot, Theme.SelectedColor, false);
+    itemToggle.graphic = checkmark;
+
+    var itemLabel = CreateLabel(item, "Item Label", "Option", TextAnchor.MiddleLeft,
+      Theme.TextColor, fontSize);
+    Stretch(itemLabel.rectTransform);
+    itemLabel.rectTransform.offsetMin = new Vector2(22, 1);
+    itemLabel.rectTransform.offsetMax = new Vector2(-6, -1);
+
+    var scrollbarRoot = CreateUIObject("Scrollbar", template);
+    var scrollbarRect = scrollbarRoot.GetComponent<RectTransform>();
+    scrollbarRect.anchorMin = new Vector2(1, 0);
+    scrollbarRect.anchorMax = Vector2.one;
+    scrollbarRect.pivot = Vector2.one;
+    scrollbarRect.sizeDelta = new Vector2(14, 0);
+    scrollbarRect.anchoredPosition = Vector2.zero;
+    AddImage(scrollbarRoot, Theme.ControlColor);
+
+    var slidingArea = CreateUIObject("Sliding Area", scrollbarRoot);
+    Stretch(slidingArea.GetComponent<RectTransform>());
+    var handleRoot = CreateUIObject("Handle", slidingArea);
+    Stretch(handleRoot.GetComponent<RectTransform>());
+    var handleImage = AddImage(handleRoot, Color.white);
+
+    var scrollbar = scrollbarRoot.AddComponent<Scrollbar>();
+    scrollbar.handleRect = handleRoot.GetComponent<RectTransform>();
+    scrollbar.targetGraphic = handleImage;
+    scrollbar.colors = ColorBlockFor(Theme.HandleColor);
+    scrollbar.direction = Scrollbar.Direction.BottomToTop;
+
+    var scrollRect = template.AddComponent<ScrollRect>();
+    scrollRect.content = contentRect;
+    scrollRect.viewport = viewportRect;
+    scrollRect.horizontal = false;
+    scrollRect.vertical = true;
+    scrollRect.movementType = ScrollRect.MovementType.Clamped;
+    scrollRect.verticalScrollbar = scrollbar;
+    scrollRect.verticalScrollbarVisibility =
+      ScrollRect.ScrollbarVisibility.AutoHideAndExpandViewport;
+    scrollRect.scrollSensitivity = 24;
+
+    dropdown.template = templateRect;
+    dropdown.captionText = caption;
+    dropdown.itemText = itemLabel;
+    dropdown.options.Clear();
+    if (options != null) {
+      dropdown.AddOptions([..options]);
+    }
+
+    dropdown.onValueChanged.AddListener(value => onChanged?.Invoke(value));
+    dropdown.RefreshShownValue();
+
+    var overlay = root.AddComponent<NativeDropdownOverlay>();
+    var rootCanvas = root.GetComponentInParent<Canvas>()?.rootCanvas;
+    overlay.Configure(dropdown, rootCanvas
+      ? rootCanvas.GetComponent<RectTransform>()
+      : parent.GetComponentInParent<Canvas>()?.GetComponent<RectTransform>());
+
+    template.SetActive(false);
+    return root;
+  }
+
+  internal static GameObject CreateDropdown<T>(
+    GameObject parent,
+    string name,
+    out DropdownBinding<T> binding,
+    string placeholder,
+    int fontSize,
+    Action<T> onChanged,
+    IEnumerable<DropdownOption<T>> options,
+    T selected
+  ) {
+    var root = CreateDropdown(
+      parent,
+      name,
+      out var dropdown,
+      placeholder,
+      fontSize,
+      null,
+      []
+    );
+    binding = new DropdownBinding<T>(dropdown, onChanged);
+    binding.SetOptions(options, selected);
+    return root;
+  }
+
+  internal static GameObject CreateSlider(GameObject parent, string name, out Slider slider) {
+    var root = CreateUIObject(name, parent);
+    slider = root.AddComponent<Slider>();
+
+    var background = CreateUIObject("Background", root);
+    var backgroundRect = background.GetComponent<RectTransform>();
+    backgroundRect.anchorMin = new Vector2(0, 0.5f);
+    backgroundRect.anchorMax = new Vector2(1, 0.5f);
+    backgroundRect.sizeDelta = new Vector2(0, 4);
+    AddImage(background, Theme.SliderColor);
+
+    var fillArea = CreateUIObject("Fill Area", root);
+    var fillAreaRect = fillArea.GetComponent<RectTransform>();
+    fillAreaRect.anchorMin = new Vector2(0, 0.5f);
+    fillAreaRect.anchorMax = new Vector2(1, 0.5f);
+    fillAreaRect.pivot = new Vector2(0.5f, 0.5f);
+    fillAreaRect.anchoredPosition = Vector2.zero;
+    fillAreaRect.sizeDelta = new Vector2(0, 4);
+
+    var fill = CreateUIObject("Fill", fillArea);
+    var fillRect = fill.GetComponent<RectTransform>();
+    Stretch(fillRect);
+    var fillImage = AddImage(fill, Theme.SelectedColor, false);
+
+    var handleArea = CreateUIObject("Handle Slide Area", root);
+    var handleAreaRect = handleArea.GetComponent<RectTransform>();
+    Stretch(handleAreaRect);
+
+    var handle = CreateUIObject("Handle", handleArea);
+    var handleRect = handle.GetComponent<RectTransform>();
+    handleRect.sizeDelta = new Vector2(10, 16);
+    var handleImage = AddImage(handle, Color.white);
+
+    slider.fillRect = fillRect;
+    slider.handleRect = handleRect;
+    slider.targetGraphic = handleImage;
+    slider.colors = ColorBlockFor(Theme.HandleColor);
+    slider.direction = Slider.Direction.LeftToRight;
+    return root;
+  }
+
+  internal static GameObject CreateToggle(
+    GameObject parent,
+    string name,
+    out Toggle toggle,
+    out Text text
+  ) {
+    var root = CreateUIObject(name, parent);
+    AddImage(root, Color.clear);
+    var layout = root.AddComponent<HorizontalLayoutGroup>();
+    layout.childAlignment = TextAnchor.MiddleLeft;
+    layout.childControlHeight = true;
+    layout.childControlWidth = true;
+    layout.childForceExpandHeight = false;
+    layout.childForceExpandWidth = false;
+    layout.spacing = 6;
+
+    var box = CreateUIObject("Background", root);
+    var boxImage = AddImage(box, Color.white);
+    SetLayoutElement(box, 20, 20);
+
+    var check = CreateUIObject("Checkmark", box);
+    var checkRect = check.GetComponent<RectTransform>();
+    Stretch(checkRect);
+    checkRect.offsetMin = new Vector2(4, 4);
+    checkRect.offsetMax = new Vector2(-4, -4);
+    var checkImage = AddImage(check, Theme.SelectedColor, false);
+
+    toggle = root.AddComponent<Toggle>();
+    toggle.targetGraphic = boxImage;
+    toggle.graphic = checkImage;
+    toggle.colors = ColorBlockFor(Theme.ControlColor);
+
+    text = CreateLabel(root, "Label", string.Empty);
+    SetLayoutElement(text.gameObject, minHeight: 20, flexibleWidth: 1);
+    return root;
+  }
+
+  internal static GameObject CreateVerticalGroup(
+    GameObject parent,
+    string name,
+    bool forceHeight,
+    bool forceWidth,
+    bool childControlHeight,
+    bool childControlWidth,
+    float spacing,
+    Vector4 padding
+  ) {
+    var root = CreateUIObject(name, parent);
+    AddImage(root, Theme.PanelColor, false);
+    SetLayoutGroup<VerticalLayoutGroup>(
+      root,
+      forceHeight,
+      forceWidth,
+      childControlHeight,
+      childControlWidth,
+      spacing,
+      (int)padding.x,
+      (int)padding.y,
+      (int)padding.z,
+      (int)padding.w
+    );
+    root.AddComponent<ContentSizeFitter>().verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+    return root;
+  }
+
+  internal static GameObject CreateGridGroup(
+    GameObject parent,
+    string name,
+    Vector2 cellSize,
+    Vector2 spacing,
+    Color color
+  ) {
+    var root = CreateUIObject(name, parent);
+    AddImage(root, color, false);
+    var grid = root.AddComponent<GridLayoutGroup>();
+    grid.cellSize = cellSize;
+    grid.spacing = spacing;
+    grid.childAlignment = TextAnchor.UpperLeft;
+    grid.constraint = GridLayoutGroup.Constraint.FixedColumnCount;
+    grid.constraintCount = 8;
+    var fitter = root.AddComponent<ContentSizeFitter>();
+    fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+    return root;
+  }
+
+  internal static GameObject CreateScrollView(GameObject parent, string name,
+    out GameObject content) {
+    var root = CreateUIObject(name, parent);
+    Stretch(root.GetComponent<RectTransform>());
+
+    var viewport = CreateUIObject("Viewport", root);
+    var viewportRect = viewport.GetComponent<RectTransform>();
+    Stretch(viewportRect);
+    AddImage(viewport, new Color(0, 0, 0, 0.01f));
+    viewport.AddComponent<RectMask2D>();
+
+    content = CreateUIObject("Content", viewport);
+    var contentRect = content.GetComponent<RectTransform>();
+    contentRect.anchorMin = new Vector2(0, 1);
+    contentRect.anchorMax = new Vector2(1, 1);
+    contentRect.pivot = new Vector2(0.5f, 1);
+    contentRect.anchoredPosition = Vector2.zero;
+    contentRect.sizeDelta = Vector2.zero;
+
+    var scroll = root.AddComponent<ScrollRect>();
+    scroll.content = contentRect;
+    scroll.viewport = viewportRect;
+    scroll.horizontal = false;
+    scroll.vertical = true;
+    scroll.movementType = ScrollRect.MovementType.Clamped;
+    scroll.scrollSensitivity = 30;
+    return root;
+  }
+
+  internal static T SetLayoutGroup<T>(
+    GameObject target,
+    bool forceHeight = false,
+    bool forceWidth = false,
+    bool childControlHeight = false,
+    bool childControlWidth = false,
+    float spacing = 0,
+    int padTop = 0,
+    int padLeft = 0,
+    int padRight = 0,
+    int padBottom = 0,
+    TextAnchor childAlignment = TextAnchor.UpperLeft
+  ) where T : HorizontalOrVerticalLayoutGroup {
+    var layout = target.GetComponent<T>() ?? target.AddComponent<T>();
+    layout.childForceExpandHeight = forceHeight;
+    layout.childForceExpandWidth = forceWidth;
+    layout.childControlHeight = childControlHeight;
+    layout.childControlWidth = childControlWidth;
+    layout.spacing = spacing;
+    layout.padding = new RectOffset(padLeft, padRight, padTop, padBottom);
+    layout.childAlignment = childAlignment;
+    return layout;
+  }
+
+  internal static LayoutElement SetLayoutElement(
+    GameObject target,
+    float minWidth = 0,
+    float minHeight = 0,
+    float flexibleWidth = 0,
+    float flexibleHeight = 0
+  ) {
+    var layout = target.GetComponent<LayoutElement>() ?? target.AddComponent<LayoutElement>();
+    if (minWidth > 0) {
+      layout.minWidth = minWidth;
+      layout.preferredWidth = minWidth;
+    }
+
+    if (minHeight > 0) {
+      layout.minHeight = minHeight;
+      layout.preferredHeight = minHeight;
+    }
+
+    layout.flexibleWidth = flexibleWidth;
+    layout.flexibleHeight = flexibleHeight;
+    return layout;
+  }
+
+  internal static void CloseDropdowns(GameObject root) {
+    if (!root) return;
+    foreach (var dropdown in root.GetComponentsInChildren<Dropdown>(true)) {
+      dropdown.Hide();
+    }
+  }
+
+  internal static ColorBlock ColorBlockFor(Color baseColor) {
+    return new ColorBlock {
+      normalColor = baseColor,
+      highlightedColor = baseColor * 1.2f,
+      pressedColor = baseColor * 0.75f,
+      selectedColor = baseColor * 1.1f,
+      disabledColor = new Color(baseColor.r, baseColor.g, baseColor.b, 0.45f),
+      colorMultiplier = 1,
+      fadeDuration = 0.08f
+    };
+  }
+
+  internal static void Stretch(RectTransform rect) {
+    rect.anchorMin = Vector2.zero;
+    rect.anchorMax = Vector2.one;
+    rect.pivot = new Vector2(0.5f, 0.5f);
+    rect.anchoredPosition = Vector2.zero;
+    rect.sizeDelta = Vector2.zero;
+  }
+}

--- a/UI/Panels/EyesPanel.cs
+++ b/UI/Panels/EyesPanel.cs
@@ -1,8 +1,8 @@
 ﻿using System.Linq;
 using daymxn.DHG.ItemSpawner.game;
+using daymxn.DHG.ItemSpawner.ui.Native;
 using UnityEngine;
 using UnityEngine.UI;
-using UniverseLib.UI;
 using Vector2 = UnityEngine.Vector2;
 
 namespace daymxn.DHG.ItemSpawner.ui.Panels;
@@ -10,10 +10,10 @@ namespace daymxn.DHG.ItemSpawner.ui.Panels;
 /// <summary>
 ///   Panel for spawning in Abyss Eyes.
 /// </summary>
-public class EyesPanel(UIBase owner) : GamePanel(owner) {
-  private Dropdown[] _powerDropdowns;
+public class EyesPanel(GameObject owner) : GamePanel(owner) {
+  private DropdownBinding<AbyssPower.Name>[] _powerDropdowns;
 
-  private Dropdown _qualityDropdown;
+  private DropdownBinding<Quality> _qualityDropdown;
   public override string Name => "Abyss Eyes";
   public override int MinWidth => 300;
   public override int MinHeight => 450;
@@ -21,15 +21,14 @@ public class EyesPanel(UIBase owner) : GamePanel(owner) {
   public override Vector2 DefaultAnchorMax => new(1f, .5f);
   public override bool CanDragAndResize => true;
   public override bool IncludeInNavbar => true;
-  protected override bool IncludeBodyFitter => true;
-
   protected override bool PivotToAnchor => true;
   protected override Vector2 PivotOffset => new(-100, 0);
 
   public override bool RequiresGameData => true;
 
   protected override void CreateBodyContent() {
-    _powerDropdowns = new Dropdown[GameData.Qualities.Highest.GetPowerSlots()];
+    _powerDropdowns =
+      new DropdownBinding<AbyssPower.Name>[GameData.Qualities.Highest.GetPowerSlots()];
 
     AddQualityDropdown();
 
@@ -41,29 +40,29 @@ public class EyesPanel(UIBase owner) : GamePanel(owner) {
     var container = UIFactory.CreateUIObject("Container", Body);
     UIFactory.SetLayoutGroup<VerticalLayoutGroup>(
       container,
-      forceHeight: false,
-      forceWidth: false,
-      childControlHeight: true,
-      childControlWidth: true,
+      false,
+      true,
+      true,
+      true,
       childAlignment: TextAnchor.LowerCenter
     );
-    UIFactory.SetLayoutElement(container, flexibleHeight: 1);
+    UIFactory.SetLayoutElement(container, flexibleWidth: 1, flexibleHeight: 1);
 
     var button = UIFactory.CreateButton(container, "SpawnButton", "Spawn", Theme.SelectedColor);
-    UIFactory.SetLayoutElement(button.Component.gameObject, 200, 25, 1);
+    UIFactory.SetLayoutElement(button.gameObject, 200, 25, 1);
 
-    button.OnClick += OnSpawnClicked;
+    button.onClick.AddListener(OnSpawnClicked);
   }
 
   private void AddQualityDropdown() {
     var container = UIFactory.CreateUIObject("Container", Body);
     UIFactory.SetLayoutGroup<VerticalLayoutGroup>(
       container,
-      forceHeight: false,
-      forceWidth: false,
-      childControlHeight: true,
-      childControlWidth: true,
-      spacing: 10,
+      false,
+      false,
+      true,
+      true,
+      10,
       padBottom: 20
     );
 
@@ -77,11 +76,11 @@ public class EyesPanel(UIBase owner) : GamePanel(owner) {
       "Quality",
       14,
       OnQualityChanged,
-      GameData.Qualities.Names
+      GameData.Qualities.All.Select(value =>
+        new DropdownOption<Quality>(value.GetNameStr(), value)),
+      GameData.Qualities.Highest
     );
     UIFactory.SetLayoutElement(quality, 200, 25, 1);
-
-    _qualityDropdown.value = GameData.Qualities.Highest.GetValue();
   }
 
   private void AddPowerDropdowns() {
@@ -91,15 +90,16 @@ public class EyesPanel(UIBase owner) : GamePanel(owner) {
     var container = UIFactory.CreateUIObject("Container", Body);
     UIFactory.SetLayoutGroup<VerticalLayoutGroup>(
       container,
-      forceHeight: false,
-      forceWidth: false,
-      childControlHeight: true,
-      childControlWidth: true,
-      spacing: 10,
+      false,
+      false,
+      true,
+      true,
+      10,
       padBottom: 40
     );
 
-    var powers = AbyssPower.prefabs.Select(power => power.GetNameStr()).ToArray();
+    var powers = AbyssPower.prefabs.Select(power =>
+      new DropdownOption<AbyssPower.Name>(power.GetNameStr(), power.name)).ToArray();
     for (var i = 0; i < _powerDropdowns.Length; i++) {
       var dropdown = UIFactory.CreateDropdown(
         container,
@@ -107,15 +107,16 @@ public class EyesPanel(UIBase owner) : GamePanel(owner) {
         out _powerDropdowns[i],
         "Power",
         14,
-        _ => { },
-        powers
+        null,
+        powers,
+        powers.Length > 0 ? powers[0].Value : default
       );
       UIFactory.SetLayoutElement(dropdown, 200, 25, 1);
     }
   }
 
-  private void OnQualityChanged(int qualityIndex) {
-    TogglePowersFromQuality(qualityIndex);
+  private void OnQualityChanged(Quality quality) {
+    TogglePowersFromQuality(quality);
   }
 
   /// <summary>
@@ -127,28 +128,40 @@ public class EyesPanel(UIBase owner) : GamePanel(owner) {
   /// <remarks>
   ///   Called when the selected Quality changes.
   /// </remarks>
-  /// <param name="qualityIndex">The int value of the quality that was selected.</param>
-  private void TogglePowersFromQuality(int qualityIndex) {
-    var quality = GameData.Qualities.FromInt(qualityIndex);
+  /// <param name="quality">The quality that was selected.</param>
+  private void TogglePowersFromQuality(Quality quality) {
     var powerSlots = quality.GetPowerSlots();
 
     for (var i = 0; i < _powerDropdowns.Length; i++) {
-      _powerDropdowns[i]?.gameObject.SetActive(i < powerSlots);
+      _powerDropdowns[i]?.Component.gameObject.SetActive(i < powerSlots);
     }
   }
 
   private void OnSpawnClicked() {
-    var quality = GameData.Qualities.FromInt(_qualityDropdown.value);
+    if (!_qualityDropdown.HasValue ||
+        _powerDropdowns.Take(_qualityDropdown.Value.GetPowerSlots())
+          .Any(binding => binding == null || !binding.HasValue)) {
+      UIManager.SendNotification(Level.Error, "No valid abyss powers are available.");
+      return;
+    }
+
+    var quality = _qualityDropdown.Value;
     var eye = AbyssEye.MakeEmptyAbyssEye(quality);
 
     var powers = _powerDropdowns
       .Take(quality.GetPowerSlots())
-      .Select(it => AbyssPower.prefabs[it.value].name)
+      .Where(it => it is { HasValue: true })
+      .Select(it => it.Value)
       .ToArray();
 
     eye.AddPowers(powers);
 
     Inventory.SpawnAbyssEye(eye);
     UIManager.SendNotification(Level.Success, "Spawned abyss eye!");
+  }
+
+  protected override void OnBodyDestroyed() {
+    _powerDropdowns = null;
+    _qualityDropdown = null;
   }
 }

--- a/UI/Panels/GamePanel.cs
+++ b/UI/Panels/GamePanel.cs
@@ -1,94 +1,307 @@
-﻿using daymxn.DHG.ItemSpawner.game;
+using System;
+using daymxn.DHG.ItemSpawner.game;
+using daymxn.DHG.ItemSpawner.ui.Native;
 using daymxn.DHG.ItemSpawner.util;
 using UnityEngine;
 using UnityEngine.UI;
-using UniverseLib.UI;
-using UniverseLib.UI.Panels;
+using Object = UnityEngine.Object;
 
 namespace daymxn.DHG.ItemSpawner.ui.Panels;
 
 /// <summary>
-///   Common base panel that provides additional defaults and functionality over PanelBase.
+///   Common native-uGUI window lifecycle for item-spawner panels.
 /// </summary>
-public abstract class GamePanel(UIBase owner) : PanelBase(owner) {
+public abstract class GamePanel(GameObject owner) : IDisposable {
+  private const float MaximumDefaultHeightRatio = 0.8f;
+  private const float MaximumDefaultWidthRatio = 0.9f;
+  private const float TitleBarHeight = 30;
+
+  private GameObject _bodyRoot;
+  private bool _constructed;
+  private bool _disposed;
+  private bool _enabled;
+  private Vector2 _lastCanvasSize;
+
   protected GameObject Body;
+  protected GameObject ContentRoot;
+  protected RectTransform Rect;
+  protected GameObject UIRoot;
+
   public virtual bool IncludeInNavbar => false;
   public virtual bool RequiresGameData => false;
-
   public virtual bool ShowByDefault => true;
+  public virtual bool CanDragAndResize => false;
+  public virtual int MinWidth => 250;
+  public virtual int MinHeight => 200;
+  public virtual int DefaultWidth => MinWidth;
+  public virtual int DefaultHeight => MinHeight;
+  public virtual Vector2 DefaultAnchorMin => new(0.5f, 0.5f);
+  public virtual Vector2 DefaultAnchorMax => DefaultAnchorMin;
+  public abstract string Name { get; }
+
   protected virtual int Spacing => 10;
   protected virtual Padding RootPadding => Padding.Of(10);
   protected virtual bool PivotToAnchor => false;
-  protected virtual Vector2 PivotOffset => new(0, 0);
-  protected virtual bool IncludeBodyFitter => false;
+  protected virtual Vector2 PivotOffset => Vector2.zero;
+  protected virtual bool UseScrollView => false;
+  protected virtual bool ShowTitleBar => true;
 
-  public override void ConstructUI() {
-    base.ConstructUI();
+  public bool Enabled {
+    get => _enabled;
+    private set {
+      if (_enabled == value) return;
+      _enabled = value;
+      if (UIRoot) UIRoot.SetActive(value);
+      if (value && Rect) Rect.SetAsLastSibling();
+      OnToggleEnabled?.Invoke(value);
+    }
+  }
+
+  protected GameObject Owner => owner;
+
+  public virtual void Dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    GameData.OnPlayerDataLoaded -= OnPlayerDataLoaded;
+    GameData.OnPlayerDataUnloaded -= OnPlayerDataUnloaded;
+    OnDisposing();
+    if (UIRoot) Object.Destroy(UIRoot);
+    UIRoot = null;
+    ContentRoot = null;
+    Body = null;
+    _bodyRoot = null;
+  }
+
+  public event Action<bool> OnToggleEnabled;
+
+  internal void ConstructUI() {
+    if (_constructed || _disposed) return;
+    _constructed = true;
+    ConstructWindow();
+
     if (RequiresGameData) {
-      GameData.OnPlayerDataLoaded += (_, _) => {
+      GameData.OnPlayerDataLoaded += OnPlayerDataLoaded;
+      GameData.OnPlayerDataUnloaded += OnPlayerDataUnloaded;
+      if (GameData.IsPlayerDataLoaded()) {
         ConstructPanelContent();
         SetActive(ShowByDefault);
-      };
-      GameData.OnPlayerDataUnloaded += (_, _) => {
-        Object.Destroy(Body);
+      } else {
         SetActive(false);
-      };
-
-      SetActive(false);
+      }
     } else {
+      ConstructPanelContent();
       SetActive(ShowByDefault);
     }
   }
 
-  public override void SetActive(bool active) {
-    // ensure the OnEnableToggled callback is invoked
+  public void Toggle() {
+    SetActive(!Enabled);
+  }
+
+  public virtual void SetActive(bool active) {
+    if (_disposed) return;
+    if (!active && UIRoot) UIFactory.CloseDropdowns(UIRoot);
+    if (active) ClampToCanvas();
     Enabled = active;
   }
 
-  protected override void ConstructPanelContent() {
-    if (RequiresGameData && !GameData.IsPlayerDataLoaded()) return;
+  public virtual void Update() {
+  }
 
-    Body = UIFactory.CreateUIObject("Body", ContentRoot);
+  internal void RefreshCanvasLayout() {
+    ResizeForCanvasChange();
+    ClampToCanvas();
+  }
+
+  protected virtual void OnDisposing() {
+  }
+
+  protected virtual void ConstructPanelContent() {
+    if (_disposed || Body || (RequiresGameData && !GameData.IsPlayerDataLoaded())) return;
+
+    if (UseScrollView) {
+      _bodyRoot = UIFactory.CreateScrollView(ContentRoot, "BodyScrollView", out Body);
+    } else {
+      _bodyRoot = UIFactory.CreateUIObject("BodyRoot", ContentRoot);
+      var bodyRootRect = _bodyRoot.GetComponent<RectTransform>();
+      UIFactory.Stretch(bodyRootRect);
+      Body = UIFactory.CreateUIObject("Body", _bodyRoot);
+      UIFactory.Stretch(Body.GetComponent<RectTransform>());
+    }
+
     UIFactory.SetLayoutGroup<VerticalLayoutGroup>(
       Body,
-      forceHeight: false,
-      forceWidth: false,
-      childControlHeight: true,
-      childControlWidth: true,
-      spacing: Spacing,
-      padTop: RootPadding.Top,
-      padLeft: RootPadding.Left,
-      padRight: RootPadding.Right,
-      padBottom: RootPadding.Bottom
+      false,
+      false,
+      true,
+      true,
+      Spacing,
+      RootPadding.Top,
+      RootPadding.Left,
+      RootPadding.Right,
+      RootPadding.Bottom
     );
 
-    if (IncludeBodyFitter) {
-      var fitter = Rect.gameObject.AddComponent<ContentSizeFitter>();
-      fitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
-      fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+    if (UseScrollView) {
+      Body.AddComponent<ContentSizeFitter>().verticalFit =
+        ContentSizeFitter.FitMode.PreferredSize;
     }
 
     CreateBodyContent();
+    ForceRebuildLayout();
   }
 
-  /// <summary>
-  ///   Use this instead of "ConstructPanelContent".
-  /// </summary>
   protected abstract void CreateBodyContent();
 
-  protected override void LateConstructUI() {
-    base.LateConstructUI();
-    if (!PivotToAnchor) return;
-
-    Rect.pivot = DefaultAnchorMin;
-    Rect.anchoredPosition = PivotOffset;
+  protected void ForceRebuildLayout() {
+    if (!Rect) return;
+    Canvas.ForceUpdateCanvases();
+    if (Body) LayoutRebuilder.ForceRebuildLayoutImmediate(Body.GetComponent<RectTransform>());
+    LayoutRebuilder.ForceRebuildLayoutImmediate(Rect);
+    ClampToCanvas();
   }
 
-  /// <summary>
-  ///   Forcibly rebuild the layout.
-  /// </summary>
-  protected void ForceRebuildLayout() {
-    Canvas.ForceUpdateCanvases();
-    LayoutRebuilder.ForceRebuildLayoutImmediate(Rect);
+  private void ConstructWindow() {
+    UIRoot = UIFactory.CreateUIObject(Name, owner);
+    Rect = UIRoot.GetComponent<RectTransform>();
+    Rect.anchorMin = DefaultAnchorMin;
+    Rect.anchorMax = DefaultAnchorMax;
+    Rect.pivot = PivotToAnchor ? DefaultAnchorMin : new Vector2(0.5f, 0.5f);
+    Rect.anchoredPosition = PivotOffset;
+    var parent = owner.GetComponent<RectTransform>();
+    _lastCanvasSize = GetCanvasSize(parent);
+    Rect.sizeDelta = CanDragAndResize
+      ? GetResponsiveDefaultSize(_lastCanvasSize)
+      : new Vector2(DefaultWidth, DefaultHeight);
+    UIFactory.AddImage(UIRoot, Theme.WindowColor);
+
+    var focus = UIRoot.AddComponent<NativeWindowFocusHandler>();
+    focus.Configure(Rect);
+
+    var contentTop = ShowTitleBar ? -TitleBarHeight : 0;
+    ContentRoot = UIFactory.CreateUIObject("Content", UIRoot);
+    var contentRect = ContentRoot.GetComponent<RectTransform>();
+    UIFactory.Stretch(contentRect);
+    contentRect.offsetMax = new Vector2(0, contentTop);
+    UIFactory.AddImage(ContentRoot, Theme.PanelColor);
+
+    if (ShowTitleBar) ConstructTitleBar();
+    if (CanDragAndResize) ConstructResizeHandle();
+
+    UIRoot.SetActive(false);
+    ClampToCanvas();
+  }
+
+  private void ConstructTitleBar() {
+    var titleBar = UIFactory.CreateUIObject("TitleBar", UIRoot);
+    var titleRect = titleBar.GetComponent<RectTransform>();
+    titleRect.anchorMin = new Vector2(0, 1);
+    titleRect.anchorMax = Vector2.one;
+    titleRect.pivot = new Vector2(0.5f, 1);
+    titleRect.anchoredPosition = Vector2.zero;
+    titleRect.sizeDelta = new Vector2(0, TitleBarHeight);
+    UIFactory.AddImage(titleBar, Theme.HeaderColor);
+
+    var title = UIFactory.CreateLabel(titleBar, "Title", Name);
+    UIFactory.Stretch(title.rectTransform);
+    title.rectTransform.offsetMin = new Vector2(10, 0);
+    title.rectTransform.offsetMax = new Vector2(-34, 0);
+
+    var close = UIFactory.CreateButton(titleBar, "CloseButton", "−", Theme.HandleColor);
+    var closeRect = close.GetComponent<RectTransform>();
+    closeRect.anchorMin = new Vector2(1, 0.5f);
+    closeRect.anchorMax = new Vector2(1, 0.5f);
+    closeRect.pivot = new Vector2(1, 0.5f);
+    closeRect.anchoredPosition = new Vector2(-3, 0);
+    closeRect.sizeDelta = new Vector2(25, 24);
+    close.onClick.AddListener(() => SetActive(false));
+
+    if (!CanDragAndResize) return;
+    var canvas = owner.GetComponentInParent<Canvas>();
+    var drag = titleBar.AddComponent<NativeWindowDragHandler>();
+    drag.Configure(Rect, owner.GetComponent<RectTransform>(), canvas);
+  }
+
+  private void ConstructResizeHandle() {
+    var handle = UIFactory.CreateUIObject("ResizeHandle", UIRoot);
+    var handleRect = handle.GetComponent<RectTransform>();
+    handleRect.anchorMin = new Vector2(1, 0);
+    handleRect.anchorMax = new Vector2(1, 0);
+    handleRect.pivot = new Vector2(1, 0);
+    handleRect.anchoredPosition = Vector2.zero;
+    handleRect.sizeDelta = new Vector2(16, 16);
+    UIFactory.AddImage(handle, Theme.HandleColor);
+
+    var resize = handle.AddComponent<NativeWindowResizeHandler>();
+    resize.Configure(
+      Rect,
+      owner.GetComponent<RectTransform>(),
+      owner.GetComponentInParent<Canvas>(),
+      new Vector2(MinWidth, MinHeight)
+    );
+  }
+
+  private void OnPlayerDataLoaded(object sender, EventArgs args) {
+    if (_disposed) return;
+    ConstructPanelContent();
+    SetActive(ShowByDefault);
+  }
+
+  private void OnPlayerDataUnloaded(object sender, EventArgs args) {
+    if (_disposed) return;
+    SetActive(false);
+    if (_bodyRoot) Object.Destroy(_bodyRoot);
+    _bodyRoot = null;
+    Body = null;
+    OnBodyDestroyed();
+  }
+
+  protected virtual void OnBodyDestroyed() {
+  }
+
+  private void ClampToCanvas() {
+    if (!Rect || !owner) return;
+    var parent = owner.GetComponent<RectTransform>();
+    NativeWindowLayout.ClampSize(Rect, parent, new Vector2(MinWidth, MinHeight));
+    NativeWindowLayout.ClampToParent(Rect, parent);
+  }
+
+  private void ResizeForCanvasChange() {
+    if (!CanDragAndResize || !Rect || !owner) return;
+
+    var parent = owner.GetComponent<RectTransform>();
+    var canvasSize = GetCanvasSize(parent);
+    if (canvasSize.x <= 1 || canvasSize.y <= 1) return;
+
+    if (_lastCanvasSize is { x: > 1, y: > 1 } &&
+        Mathf.Approximately(canvasSize.x, _lastCanvasSize.x) &&
+        Mathf.Approximately(canvasSize.y, _lastCanvasSize.y)) {
+      return;
+    }
+
+    var responsiveMaximum = GetResponsiveDefaultSize(canvasSize);
+    Rect.sizeDelta = new Vector2(
+      Mathf.Min(Rect.sizeDelta.x, responsiveMaximum.x),
+      Mathf.Min(Rect.sizeDelta.y, responsiveMaximum.y)
+    );
+    _lastCanvasSize = canvasSize;
+  }
+
+  private Vector2 GetResponsiveDefaultSize(Vector2 canvasSize) {
+    if (canvasSize.x <= 1 || canvasSize.y <= 1) {
+      return new Vector2(DefaultWidth, DefaultHeight);
+    }
+
+    var maximumWidth = canvasSize.x * MaximumDefaultWidthRatio;
+    var maximumHeight = canvasSize.y * MaximumDefaultHeightRatio;
+    return new Vector2(
+      Mathf.Min(DefaultWidth, maximumWidth),
+      Mathf.Min(DefaultHeight, maximumHeight)
+    );
+  }
+
+  private static Vector2 GetCanvasSize(RectTransform canvas) {
+    var canvasSize = canvas ? canvas.rect.size : Vector2.zero;
+    return canvasSize is { x: > 1, y: > 1 } ? canvasSize : new Vector2(Screen.width, Screen.height);
   }
 }

--- a/UI/Panels/ImageSelectorModal.cs
+++ b/UI/Panels/ImageSelectorModal.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using daymxn.DHG.ItemSpawner.ui.Native;
 using UnityEngine;
-using UniverseLib;
-using UniverseLib.UI;
+using UnityEngine.UI;
 using Object = UnityEngine.Object;
 
 namespace daymxn.DHG.ItemSpawner.ui.Panels;
@@ -10,9 +10,10 @@ namespace daymxn.DHG.ItemSpawner.ui.Panels;
 /// <summary>
 ///   An Image that is selectable via a <see cref="ImageSelectorModal" />.
 /// </summary>
-/// <param name="Image">The sprite image to display.</param>
-/// <param name="Value">The underlying value (typically an index).</param>
-public record struct SelectableImage(Sprite Image, int Value);
+public readonly struct SelectableImage<T>(Sprite image, T value) {
+  public Sprite Image { get; } = image;
+  public T Value { get; } = value;
+}
 
 /// <summary>
 ///   Popup modal which presents a grid of clickable images.
@@ -22,26 +23,41 @@ public record struct SelectableImage(Sprite Image, int Value);
 /// </remarks>
 /// <seealso cref="ItemSpawner.ui.Widgets.ImageSelector.ImageSelector" />
 /// <seealso cref="Open" />
-public class ImageSelectorModal(UIBase owner) : GamePanel(owner) {
+public class ImageSelectorModal(GameObject owner) : GamePanel(owner) {
+  private const int ColumnCount = 8;
+  private const float CellSize = 50;
+  private const float GridSpacing = 4;
+  private const float ModalWidth = ColumnCount * CellSize + (ColumnCount - 1) * GridSpacing + 20;
+  private const float TitleBarHeight = 30;
+  private const float VerticalPadding = 20;
+
   private static readonly Color SelectedColor = new(45 / 255f, 75 / 255f, 80 / 255f);
   private static readonly Color InactiveColor = new(1f, 1f, 1f);
   private readonly List<GameObject> _buttons = [];
 
+  private GameObject _blocker;
   private GameObject _grid;
 
   public static ImageSelectorModal Instance =>
     UIManager.GetPanel<ImageSelectorModal>(UIManager.Panels.ImageSelectorModal);
 
   public override string Name => "Select";
-  public override int MinWidth => 500;
-  public override int MinHeight => 500;
+  public override int MinWidth => (int)ModalWidth;
+  public override int MinHeight => 200;
+  public override int DefaultWidth => (int)ModalWidth;
+  public override int DefaultHeight => 600;
   public override Vector2 DefaultAnchorMin => new(0.5f, 0.5f);
   public override Vector2 DefaultAnchorMax => new(0.5f, 0.5f);
   public override bool ShowByDefault => false;
 
   protected override bool PivotToAnchor => true;
 
-  protected override bool IncludeBodyFitter => true;
+  protected override bool UseScrollView => true;
+
+  public override void SetActive(bool active) {
+    base.SetActive(active);
+    if (!active && _blocker) _blocker.SetActive(false);
+  }
 
   /// <summary>
   ///   Open the modal with the selected values.
@@ -49,31 +65,41 @@ public class ImageSelectorModal(UIBase owner) : GamePanel(owner) {
   /// <param name="selectedImage">The currently selected image.</param>
   /// <param name="images">A list of selectable images to present.</param>
   /// <param name="onSelect">Callback invoked when the user clicks an image.</param>
-  public void Open(SelectableImage selectedImage, List<SelectableImage> images,
-    Action<SelectableImage> onSelect) {
-    UIRoot.SetActive(true);
+  public void Open<T>(
+    SelectableImage<T> selectedImage,
+    IReadOnlyList<SelectableImage<T>> images,
+    Action<SelectableImage<T>> onSelect
+  ) {
+    UIManager.CloseAllDropdowns();
+    ResizeForItemCount(images.Count);
+    _blocker.SetActive(true);
+    _blocker.transform.SetAsLastSibling();
+    SetActive(true);
     UIRoot.transform.SetAsLastSibling();
 
     Clear();
 
     foreach (var selectable in images) {
       var button = UIFactory.CreateButton(_grid, $"Button_{selectable.Value}", "");
-      button.Component.image.sprite = selectable.Image;
-      button.OnClick += () => {
+      button.image.sprite = selectable.Image;
+      button.onClick.AddListener(() => {
         onSelect(selectable);
         Close();
-      };
-      RuntimeHelper.SetColorBlock(button.Component,
-        selectable == selectedImage ? SelectedColor : InactiveColor);
-      UIFactory.SetLayoutElement(button.GameObject, 50, 50);
+      });
+      button.colors = UIFactory.ColorBlockFor(
+        EqualityComparer<T>.Default.Equals(selectable.Value, selectedImage.Value)
+          ? SelectedColor
+          : InactiveColor);
+      UIFactory.SetLayoutElement(button.gameObject, 50, 50);
 
-      _buttons.Add(button.GameObject);
+      _buttons.Add(button.gameObject);
     }
   }
 
   private void Close() {
     Clear();
-    UIRoot.SetActive(false);
+    SetActive(false);
+    if (_blocker) _blocker.SetActive(false);
   }
 
   private void Clear() {
@@ -85,15 +111,42 @@ public class ImageSelectorModal(UIBase owner) : GamePanel(owner) {
   }
 
   protected override void CreateBodyContent() {
+    _blocker = UIFactory.CreateUIObject("ImageSelectorBlocker", Owner);
+    UIFactory.Stretch(_blocker.GetComponent<RectTransform>());
+    var blockerImage = UIFactory.AddImage(_blocker, new Color(0, 0, 0, 0.4f));
+    var blockerButton = _blocker.AddComponent<Button>();
+    blockerButton.targetGraphic = blockerImage;
+    blockerButton.onClick.AddListener(Close);
+    _blocker.SetActive(false);
+
     _grid = UIFactory.CreateGridGroup(
       Body,
       "Grid",
-      new Vector2(50, 50),
-      new Vector2(2, 2),
+      new Vector2(CellSize, CellSize),
+      new Vector2(GridSpacing, GridSpacing),
       new Color(1, 1, 1, 0)
     );
-    UIFactory.SetLayoutElement(_grid, 580, 25, 0);
+    _grid.GetComponent<GridLayoutGroup>().constraintCount = ColumnCount;
+    UIFactory.SetLayoutElement(_grid, ModalWidth - 20, CellSize);
 
-    UIRoot.SetActive(false);
+    SetActive(false);
+  }
+
+  protected override void OnDisposing() {
+    if (_blocker) Object.Destroy(_blocker);
+    _blocker = null;
+  }
+
+  private void ResizeForItemCount(int itemCount) {
+    var rows = Mathf.Max(1, Mathf.CeilToInt(itemCount / (float)ColumnCount));
+    var gridHeight = rows * CellSize + Mathf.Max(0, rows - 1) * GridSpacing;
+    var desiredHeight = TitleBarHeight + VerticalPadding + gridHeight;
+    var canvasHeight = Owner.GetComponent<RectTransform>().rect.height;
+    var maxHeight = canvasHeight > 1 ? Mathf.Max(MinHeight, canvasHeight - 40) : DefaultHeight;
+
+    Rect.sizeDelta = new Vector2(ModalWidth,
+      Mathf.Clamp(desiredHeight, MinHeight, maxHeight));
+    Rect.anchoredPosition = Vector2.zero;
+    ForceRebuildLayout();
   }
 }

--- a/UI/Panels/Navbar.cs
+++ b/UI/Panels/Navbar.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
+using System;
 using daymxn.DHG.ItemSpawner.game;
+using daymxn.DHG.ItemSpawner.ui.Native;
 using UnityEngine;
 using UnityEngine.UI;
-using UniverseLib.UI;
-using UniverseLib.UI.Models;
 
 namespace daymxn.DHG.ItemSpawner.ui.Panels;
 
@@ -15,25 +15,13 @@ namespace daymxn.DHG.ItemSpawner.ui.Panels;
 ///   Panels are shown dynamically based on whether they have
 ///   <see cref="ItemSpawner.ui.Panels.GamePanel.IncludeInNavbar" /> set to true.
 /// </remarks>
-public class Navbar(UIBase owner) : GamePanel(owner) {
+public class Navbar(GameObject owner) : GamePanel(owner) {
   private static readonly Color EnabledColor = Theme.SelectedColor;
   private static readonly Color DisabledColor = new(0.25f, 0.25f, 0.25f);
 
-  private static readonly ColorBlock EnabledColors =
-    new() {
-      normalColor = EnabledColor,
-      highlightedColor = EnabledColor * 1.2f,
-      pressedColor = EnabledColor * 0.7f,
-      colorMultiplier = 1.0f
-    };
+  private static readonly ColorBlock EnabledColors = UIFactory.ColorBlockFor(EnabledColor);
 
-  private static readonly ColorBlock DisabledColors =
-    new() {
-      normalColor = DisabledColor,
-      highlightedColor = DisabledColor * 1.2f,
-      pressedColor = DisabledColor * 0.7f,
-      colorMultiplier = 1.0f
-    };
+  private static readonly ColorBlock DisabledColors = UIFactory.ColorBlockFor(DisabledColor);
 
   /// <summary>
   ///   Buttons that point to panels which require game data.
@@ -41,23 +29,28 @@ public class Navbar(UIBase owner) : GamePanel(owner) {
   /// <remarks>
   ///   These buttons will be enabled and disabled whenever a save slot loads and unloads.
   /// </remarks>
-  private readonly List<ButtonRef> _buttonsToTrack = [];
+  private readonly List<Button> _buttonsToTrack = [];
+  private readonly List<(GamePanel Panel, Action<bool> Handler)> _panelHandlers = [];
 
   public override string Name => "Navbar";
-  public override int MinWidth => 300;
-  public override int MinHeight => 450;
+  public override int MinWidth => 75;
+  public override int MinHeight => 150;
+  public override int DefaultWidth => 75;
+  public override int DefaultHeight => 150;
   public override Vector2 DefaultAnchorMin => new(0f, 0.5f);
   public override Vector2 DefaultAnchorMax => new(0f, 0.5f);
   public override bool CanDragAndResize => false;
   protected override bool PivotToAnchor => true;
   protected override Vector2 PivotOffset => new(10, 0);
-  protected override bool IncludeBodyFitter => true;
+  protected override bool ShowTitleBar => false;
 
   protected override void CreateBodyContent() {
+    Body.GetComponent<VerticalLayoutGroup>().childAlignment = TextAnchor.UpperCenter;
     AddButtons();
 
-    GameData.OnPlayerDataLoaded += (_, _) => { UpdateButtons(true); };
-    GameData.OnPlayerDataUnloaded += (_, _) => { UpdateButtons(false); };
+    GameData.OnPlayerDataLoaded += OnPlayerDataLoaded;
+    GameData.OnPlayerDataUnloaded += OnPlayerDataUnloaded;
+    UpdateButtons(GameData.IsPlayerDataLoaded());
   }
 
   private void AddButtons() {
@@ -66,28 +59,48 @@ public class Navbar(UIBase owner) : GamePanel(owner) {
 
       var name = panelEnum.ToString();
       var button = UIFactory.CreateButton(Body, name, name);
-      UIFactory.SetLayoutElement(button.Component.gameObject, 50, 25);
+      UIFactory.SetLayoutElement(button.gameObject, 50, 25);
 
-      panel.OnToggleEnabled += enabled => {
-        button.Component.colors = enabled ? EnabledColors : DisabledColors;
+      Action<bool> handler = enabled => {
+        button.colors = enabled ? EnabledColors : DisabledColors;
       };
+      panel.OnToggleEnabled += handler;
+      _panelHandlers.Add((panel, handler));
 
-      button.OnClick += panel.Toggle;
+      button.onClick.AddListener(panel.Toggle);
 
       if (panel.ShowByDefault) {
-        button.Component.colors = EnabledColors;
+        button.colors = EnabledColors;
       }
 
       if (!panel.RequiresGameData) continue;
 
       _buttonsToTrack.Add(button);
-      button.Component.interactable = false;
+      button.interactable = false;
     }
   }
 
   private void UpdateButtons(bool enabled) {
     foreach (var button in _buttonsToTrack) {
-      button.Component.interactable = enabled;
+      button.interactable = enabled;
     }
+  }
+
+  protected override void OnDisposing() {
+    GameData.OnPlayerDataLoaded -= OnPlayerDataLoaded;
+    GameData.OnPlayerDataUnloaded -= OnPlayerDataUnloaded;
+    foreach (var (panel, handler) in _panelHandlers) {
+      panel.OnToggleEnabled -= handler;
+    }
+
+    _panelHandlers.Clear();
+  }
+
+  private void OnPlayerDataLoaded(object sender, EventArgs args) {
+    UpdateButtons(true);
+  }
+
+  private void OnPlayerDataUnloaded(object sender, EventArgs args) {
+    UpdateButtons(false);
   }
 }

--- a/UI/Panels/NotificationPanel.cs
+++ b/UI/Panels/NotificationPanel.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
+using daymxn.DHG.ItemSpawner.ui.Native;
 using daymxn.DHG.ItemSpawner.util;
 using UnityEngine;
 using UnityEngine.UI;
-using UniverseLib.UI;
 
 namespace daymxn.DHG.ItemSpawner.ui.Panels;
 
@@ -27,7 +27,7 @@ public enum Level {
 ///   shown, and automatically disappear after a few seconds.
 /// </remarks>
 /// <seealso cref="SendNotification" />
-public class NotificationPanel(UIBase owner) : GamePanel(owner) {
+public class NotificationPanel(GameObject owner) : GamePanel(owner) {
   /// <summary>
   ///   How long to show a notification for.
   /// </summary>
@@ -40,8 +40,10 @@ public class NotificationPanel(UIBase owner) : GamePanel(owner) {
 
   private bool _open;
   public override string Name => "Notice";
-  public override int MinWidth => 10;
-  public override int MinHeight => 10;
+  public override int MinWidth => 280;
+  public override int MinHeight => 50;
+  public override int DefaultWidth => 340;
+  public override int DefaultHeight => 80;
   public override Vector2 DefaultAnchorMin => new(1f, 0f);
   public override Vector2 DefaultAnchorMax => new(1f, 0f);
   public override bool CanDragAndResize => false;
@@ -51,11 +53,11 @@ public class NotificationPanel(UIBase owner) : GamePanel(owner) {
   protected override Padding RootPadding => Padding.Of(0);
   protected override bool PivotToAnchor => true;
   protected override Vector2 PivotOffset => new(-10, 10);
-  protected override bool IncludeBodyFitter => true;
+  protected override bool ShowTitleBar => false;
 
   protected override void CreateBodyContent() {
-    Object.Destroy(ContentRoot.gameObject.GetComponent<Image>());
-    Object.Destroy(UIRoot.gameObject.GetComponent<Image>());
+    MakeNonBlocking(ContentRoot.GetComponent<Image>());
+    MakeNonBlocking(UIRoot.GetComponent<Image>());
   }
 
   /// <summary>
@@ -77,7 +79,7 @@ public class NotificationPanel(UIBase owner) : GamePanel(owner) {
 
     Object.Destroy(currentNotif.Element);
     _notifications.Dequeue();
-    ForceRebuildLayout();
+    ResizeToContent();
 
     if (_notifications.Count != 0) return;
 
@@ -105,10 +107,22 @@ public class NotificationPanel(UIBase owner) : GamePanel(owner) {
 
     Sounds.Instance.notification.Play();
     _notifications.Enqueue(new ActiveNotification(Time.realtimeSinceStartup, container));
+    ResizeToContent();
   }
 
   private void ToggleVisibility() {
     SetActive(_open);
+  }
+
+  private void ResizeToContent() {
+    if (!Body || !Rect) return;
+    Canvas.ForceUpdateCanvases();
+    var bodyRect = Body.GetComponent<RectTransform>();
+    LayoutRebuilder.ForceRebuildLayoutImmediate(bodyRect);
+    var preferredHeight = LayoutUtility.GetPreferredHeight(bodyRect);
+    Rect.sizeDelta = new Vector2(DefaultWidth,
+      Mathf.Clamp(preferredHeight, MinHeight, 500));
+    ForceRebuildLayout();
   }
 
   private static Color LevelToColor(Level level) {
@@ -119,6 +133,12 @@ public class NotificationPanel(UIBase owner) : GamePanel(owner) {
       Level.Error => Color.red,
       _ => Color.white
     };
+  }
+
+  private static void MakeNonBlocking(Image image) {
+    if (!image) return;
+    image.color = Color.clear;
+    image.raycastTarget = false;
   }
 
   /// <summary>

--- a/UI/Panels/Spawners/AffixSpawningPanel.cs
+++ b/UI/Panels/Spawners/AffixSpawningPanel.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using daymxn.DHG.ItemSpawner.game;
+using daymxn.DHG.ItemSpawner.ui.Native;
 using daymxn.DHG.ItemSpawner.ui.Widgets.Affix;
 using daymxn.DHG.ItemSpawner.ui.Widgets.ImageSelector;
 using UnityEngine;
 using UnityEngine.UI;
-using UniverseLib.UI;
 
 namespace daymxn.DHG.ItemSpawner.ui.Panels.Spawners;
 
@@ -15,13 +15,14 @@ namespace daymxn.DHG.ItemSpawner.ui.Panels.Spawners;
 /// </summary>
 /// <typeparam name="TName">The enum type for the item names.</typeparam>
 /// <typeparam name="TSpawn">The type of item.</typeparam>
-public abstract class AffixSpawningPanel<TName, TSpawn>(UIBase owner)
+public abstract class AffixSpawningPanel<TName, TSpawn>(GameObject owner)
   : GamePanel(owner) where TName : Enum where TSpawn : AffixTaker {
   private GameObject[] _affixSectionObjects;
   private AffixSection[] _affixSections;
-  private ImageSelector _imageSelector;
-  private Dropdown _qualityDropdown;
-  private List<SelectableImage> _selectables;
+  private bool _hasAffixes;
+  private ImageSelector<TName> _imageSelector;
+  private DropdownBinding<Quality> _qualityDropdown;
+  private List<SelectableImage<TName>> _selectables;
 
   /// <summary>
   ///   Name of the spawnable item.
@@ -58,10 +59,12 @@ public abstract class AffixSpawningPanel<TName, TSpawn>(UIBase owner)
   protected abstract Action<TSpawn> SpawnFunction { get; }
 
   public override int MinWidth => 400;
-  public override int MinHeight => 1200;
+  public override int MinHeight => 400;
+  public override int DefaultWidth => 500;
+  public override int DefaultHeight => 900;
   public override Vector2 DefaultAnchorMin => new(0f, 1f);
   public override Vector2 DefaultAnchorMax => new(0f, 1f);
-  protected override bool IncludeBodyFitter => true;
+  protected override bool UseScrollView => true;
   protected override bool PivotToAnchor => true;
   public override bool CanDragAndResize => true;
   public override bool IncludeInNavbar => true;
@@ -77,11 +80,37 @@ public abstract class AffixSpawningPanel<TName, TSpawn>(UIBase owner)
   protected override void CreateBodyContent() {
     _affixSections = new AffixSection[GameData.Qualities.Highest.GetPowerSlots()];
     _affixSectionObjects = new GameObject[_affixSections.Length];
-    _selectables = Icons.Select((image, index) => new SelectableImage(image, index)).ToList();
+    var icons = Icons;
+    var names = Names;
+    var selectableCount = Math.Min(icons.Count, names.Count);
+    if (icons.Count != names.Count) {
+      Plugin.Logger.LogWarning(
+        $"{Name} has {icons.Count} icons but {names.Count} names; checking {selectableCount} matched entries."
+      );
+    }
+
+    _selectables = Enumerable.Range(0, selectableCount)
+      .Where(index => HasUsableIcon(icons[index]))
+      .Select(index => new SelectableImage<TName>(icons[index], names[index]))
+      .ToList();
+    var skippedItemCount = Math.Max(0, names.Count - _selectables.Count);
+    if (skippedItemCount > 0) {
+      Plugin.Logger.LogWarning(
+        $"{Name} skipped {skippedItemCount} item entries without usable icons."
+      );
+    }
+
+    _hasAffixes = AffixPool != null &&
+                  AffixPool.Any(entry => entry.Value is { Count: > 0 });
 
     AddQualityDropdown();
     AddSelectableDropdown();
-    AddAffixSections();
+    if (_hasAffixes) {
+      AddAffixSections();
+    } else {
+      UIFactory.CreateLabel(Body, "MissingAffixes", "No affixes are available.",
+        TextAnchor.MiddleCenter, Color.red);
+    }
     AddSpawnButton();
   }
 
@@ -90,17 +119,18 @@ public abstract class AffixSpawningPanel<TName, TSpawn>(UIBase owner)
     UIFactory.SetLayoutGroup<VerticalLayoutGroup>(
       container,
       forceHeight: false,
-      forceWidth: false,
+      forceWidth: true,
       childControlHeight: true,
       childControlWidth: true,
       childAlignment: TextAnchor.LowerCenter
     );
-    UIFactory.SetLayoutElement(container, flexibleHeight: 1);
+    UIFactory.SetLayoutElement(container, flexibleWidth: 1, flexibleHeight: 1);
 
     var button = UIFactory.CreateButton(container, "SpawnButton", "Spawn", Theme.SelectedColor);
-    UIFactory.SetLayoutElement(button.Component.gameObject, 200, 25, 1);
+    UIFactory.SetLayoutElement(button.gameObject, 200, 25, 1);
 
-    button.OnClick += OnSpawnClicked;
+    button.onClick.AddListener(OnSpawnClicked);
+    button.interactable = _imageSelector != null && _qualityDropdown.HasValue && _hasAffixes;
   }
 
   private void AddQualityDropdown() {
@@ -125,15 +155,21 @@ public abstract class AffixSpawningPanel<TName, TSpawn>(UIBase owner)
       "Quality",
       14,
       OnQualityChanged,
-      GameData.Qualities.Names
+      GameData.Qualities.All.Select(value =>
+        new DropdownOption<Quality>(value.GetNameStr(), value)),
+      GameData.Qualities.Highest
     );
     UIFactory.SetLayoutElement(quality, 200, 25, 1);
-
-    _qualityDropdown.SetValueWithoutNotify(GameData.Qualities.Highest.GetValue());
   }
 
   private void AddSelectableDropdown() {
-    _imageSelector = new ImageSelector(Body, _selectables, SelectableName);
+    if (_selectables.Count == 0) {
+      UIFactory.CreateLabel(Body, "MissingItems", $"No {SelectableName} options are available.",
+        TextAnchor.MiddleCenter, Color.red);
+      return;
+    }
+
+    _imageSelector = new ImageSelector<TName>(Body, _selectables, SelectableName);
   }
 
   private void AddAffixSections() {
@@ -160,10 +196,10 @@ public abstract class AffixSpawningPanel<TName, TSpawn>(UIBase owner)
     }
   }
 
-  private void OnQualityChanged(int qualityIndex) {
-    TogglePowersFromQuality(qualityIndex);
+  private void OnQualityChanged(Quality quality) {
+    if (!_hasAffixes) return;
+    TogglePowersFromQuality(quality);
 
-    var quality = GameData.Qualities.FromInt(qualityIndex);
     foreach (var section in _affixSections) {
       if (section == null) break;
 
@@ -180,9 +216,8 @@ public abstract class AffixSpawningPanel<TName, TSpawn>(UIBase owner)
   /// <remarks>
   ///   Called when the selected Quality changes.
   /// </remarks>
-  /// <param name="qualityIndex">The int value of the quality that was selected.</param>
-  private void TogglePowersFromQuality(int qualityIndex) {
-    var quality = GameData.Qualities.FromInt(qualityIndex);
+  /// <param name="quality">The quality that was selected.</param>
+  private void TogglePowersFromQuality(Quality quality) {
     var powerSlots = quality.GetPowerSlots();
 
     for (var i = 0; i < _affixSectionObjects.Length; i++) {
@@ -191,9 +226,14 @@ public abstract class AffixSpawningPanel<TName, TSpawn>(UIBase owner)
   }
 
   private void OnSpawnClicked() {
-    var quality = GameData.Qualities.FromInt(_qualityDropdown.value);
+    if (_imageSelector == null || !_qualityDropdown.HasValue || !_hasAffixes) {
+      UIManager.SendNotification(Level.Error, $"No {SelectableName} is available to spawn.");
+      return;
+    }
+
+    var quality = _qualityDropdown.Value;
     var powerSlots = quality.GetPowerSlots();
-    var name = Names[_imageSelector.Selected.Value];
+    var name = _imageSelector.Selected.Value;
     var item = CreateEmptyItem(name, quality);
 
     for (var i = 0; i < powerSlots; i++) {
@@ -203,5 +243,18 @@ public abstract class AffixSpawningPanel<TName, TSpawn>(UIBase owner)
 
     SpawnFunction(item);
     UIManager.SendNotification(Level.Success, $"Spawned {SelectableName}!");
+  }
+
+  protected override void OnBodyDestroyed() {
+    _affixSectionObjects = null;
+    _affixSections = null;
+    _hasAffixes = false;
+    _imageSelector = null;
+    _qualityDropdown = null;
+    _selectables = null;
+  }
+
+  private static bool HasUsableIcon(Sprite icon) {
+    return icon && icon.texture;
   }
 }

--- a/UI/Panels/Spawners/CoresPanel.cs
+++ b/UI/Panels/Spawners/CoresPanel.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using daymxn.DHG.ItemSpawner.game;
 using UnityEngine;
-using UniverseLib.UI;
 using Vector2 = UnityEngine.Vector2;
 
 namespace daymxn.DHG.ItemSpawner.ui.Panels.Spawners;
@@ -10,7 +9,7 @@ namespace daymxn.DHG.ItemSpawner.ui.Panels.Spawners;
 /// <summary>
 ///   Panel for spawning in Hunting Cores.
 /// </summary>
-public class CoresPanel(UIBase owner)
+public class CoresPanel(GameObject owner)
   : AffixSpawningPanel<HuntingCore.Name, HuntingCore>(owner) {
   public override string Name => "Hunting Cores";
   protected override Vector2 PivotOffset => new(1300, -100);

--- a/UI/Panels/Spawners/RelicsPanel.cs
+++ b/UI/Panels/Spawners/RelicsPanel.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using daymxn.DHG.ItemSpawner.game;
 using UnityEngine;
-using UniverseLib.UI;
 using Vector2 = UnityEngine.Vector2;
 
 namespace daymxn.DHG.ItemSpawner.ui.Panels.Spawners;
@@ -10,7 +9,7 @@ namespace daymxn.DHG.ItemSpawner.ui.Panels.Spawners;
 /// <summary>
 ///   Panel for spawning in Relics (badges).
 /// </summary>
-public class RelicsPanel(UIBase owner)
+public class RelicsPanel(GameObject owner)
   : AffixSpawningPanel<Badge.Name, Badge>(owner) {
   public override string Name => "Relics";
   protected override Vector2 PivotOffset => new(100, -100);

--- a/UI/Panels/Spawners/SlatesPanel.cs
+++ b/UI/Panels/Spawners/SlatesPanel.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using daymxn.DHG.ItemSpawner.game;
 using UnityEngine;
-using UniverseLib.UI;
 using Vector2 = UnityEngine.Vector2;
 
 namespace daymxn.DHG.ItemSpawner.ui.Panels.Spawners;
@@ -10,7 +9,7 @@ namespace daymxn.DHG.ItemSpawner.ui.Panels.Spawners;
 /// <summary>
 ///   Panel for spawning in Support Slates.
 /// </summary>
-public class SlatesPanel(UIBase owner)
+public class SlatesPanel(GameObject owner)
   : AffixSpawningPanel<SupportSlate.Name, SupportSlate>(owner) {
   public override string Name => "Support Slates";
   protected override Vector2 PivotOffset => new(700, -100);

--- a/UI/Theme.cs
+++ b/UI/Theme.cs
@@ -10,4 +10,12 @@ public static class Theme {
   ///   Color for selected buttons.
   /// </summary>
   public static Color SelectedColor = new(45 / 255f, 75 / 255f, 80 / 255f);
+
+  public static readonly Color WindowColor = new(0.055f, 0.055f, 0.055f, 0.98f);
+  public static readonly Color PanelColor = new(0.08f, 0.08f, 0.08f, 0.98f);
+  public static readonly Color HeaderColor = new(0.035f, 0.035f, 0.035f, 1f);
+  public static readonly Color ControlColor = new(0.035f, 0.035f, 0.035f, 1f);
+  public static readonly Color SliderColor = new(0.14f, 0.14f, 0.14f, 1f);
+  public static readonly Color HandleColor = new(0.22f, 0.22f, 0.22f, 1f);
+  public static readonly Color TextColor = new(0.92f, 0.92f, 0.92f, 1f);
 }

--- a/UI/UIManager.cs
+++ b/UI/UIManager.cs
@@ -1,19 +1,17 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 using daymxn.DHG.ItemSpawner.game;
+using daymxn.DHG.ItemSpawner.ui.Native;
 using daymxn.DHG.ItemSpawner.ui.Panels;
 using daymxn.DHG.ItemSpawner.ui.Panels.Spawners;
 using UnityEngine;
-using UniverseLib.UI;
 
 namespace daymxn.DHG.ItemSpawner.ui;
 
 /// <summary>
-///   Root controller for UI related functions.
+///   Root controller for the native item-spawner UI.
 /// </summary>
 public static class UIManager {
-  /// <summary>
-  ///   All the panels shown in the UI.
-  /// </summary>
   public enum Panels {
     Eyes,
     Relics,
@@ -26,59 +24,94 @@ public static class UIManager {
 
   internal static readonly Dictionary<Panels, GamePanel> UIPanels = new();
 
-  private static UIBase UiBase { get; set; }
-  private static GameObject UIRoot => UiBase?.RootObject;
+  private static GameObject _canvasRoot;
+  private static NativeEventSystemBridge _eventSystemBridge;
+  private static bool _initialized;
+  private static bool _reportedCanvasState;
 
-  /// <summary>
-  ///   Sounds loaded by the plugin, which can be played.
-  /// </summary>
   public static Sounds Sounds { get; private set; }
 
-
   internal static void InitUI() {
-    UiBase = UniversalUI.RegisterUI(MyPluginInfo.PLUGIN_GUID, Update);
-    UiBase.RootObject.GetComponent<RectTransform>();
-    Sounds = UiBase.RootObject.AddComponent<Sounds>();
+    if (_initialized) return;
+    _initialized = true;
 
-    UIPanels.Add(Panels.ImageSelectorModal, new ImageSelectorModal(UiBase));
+    _canvasRoot = UIFactory.CreateCanvasRoot($"{MyPluginInfo.PLUGIN_GUID}.UI");
+    _eventSystemBridge = _canvasRoot.AddComponent<NativeEventSystemBridge>();
+    Sounds = _canvasRoot.AddComponent<Sounds>();
 
-    UIPanels.Add(Panels.Notification, new NotificationPanel(UiBase));
-    UIPanels.Add(Panels.Eyes, new EyesPanel(UiBase));
-    UIPanels.Add(Panels.Relics, new RelicsPanel(UiBase));
-    UIPanels.Add(Panels.Slates, new SlatesPanel(UiBase));
-    UIPanels.Add(Panels.Cores, new CoresPanel(UiBase));
+    Register(Panels.ImageSelectorModal, new ImageSelectorModal(_canvasRoot));
+    Register(Panels.Notification, new NotificationPanel(_canvasRoot));
+    Register(Panels.Eyes, new EyesPanel(_canvasRoot));
+    Register(Panels.Relics, new RelicsPanel(_canvasRoot));
+    Register(Panels.Slates, new SlatesPanel(_canvasRoot));
+    Register(Panels.Cores, new CoresPanel(_canvasRoot));
+    Register(Panels.Navbar, new Navbar(_canvasRoot));
 
-    UIPanels.Add(Panels.Navbar, new Navbar(UiBase));
+    var eventSystem = _eventSystemBridge.Current;
+    Plugin.Logger.LogInfo(
+      _eventSystemBridge.IsUsingFallback
+        ? $"Native uGUI initialized with fallback EventSystem '{eventSystem.GetType().FullName}'."
+        : $"Native uGUI initialized; using EventSystem '{eventSystem.GetType().FullName}'.");
+
+    Canvas.ForceUpdateCanvases();
   }
 
-  /// <summary>
-  ///   Get a loaded panel, typecasting it go its specific type.
-  /// </summary>
-  /// <param name="panel">The panel to get.</param>
-  /// <typeparam name="T">The class of the panel to get.</typeparam>
-  /// <returns>The currently loaded panel for the corresponding name and type.</returns>
+  internal static void Update() {
+    if (!_initialized || !_canvasRoot) return;
+    ReportCanvasStateOnce();
+    GameData.Update();
+    foreach (var panel in UIPanels.Values.ToArray()) {
+      panel.RefreshCanvasLayout();
+      if (panel.Enabled) panel.Update();
+    }
+  }
+
+  internal static void Shutdown() {
+    if (!_initialized) return;
+    foreach (var panel in UIPanels.Values.ToArray()) {
+      panel.Dispose();
+    }
+
+    UIPanels.Clear();
+    Sounds = null;
+    _eventSystemBridge = null;
+    if (_canvasRoot) Object.Destroy(_canvasRoot);
+    _canvasRoot = null;
+    _initialized = false;
+    _reportedCanvasState = false;
+  }
+
   public static T GetPanel<T>(Panels panel) where T : GamePanel {
     return GetPanel(panel) as T;
   }
 
-  private static GamePanel GetPanel(Panels panel) {
-    return UIPanels[panel];
-  }
-
-  /// <summary>
-  ///   Sends a notification to display to the user.
-  /// </summary>
-  /// <param name="level">The type of notification to send.</param>
-  /// <param name="message">The text to show in the notification.</param>
-  /// <seealso cref="NotificationPanel" />
   public static void SendNotification(Level level, string message) {
     GetPanel<NotificationPanel>(Panels.Notification)?.SendNotification(level, message);
   }
 
-  private static void Update() {
-    if (!UIRoot)
-      return;
+  internal static void CloseAllDropdowns() {
+    if (_canvasRoot) UIFactory.CloseDropdowns(_canvasRoot);
+  }
 
-    GameData.Update();
+  private static GamePanel GetPanel(Panels panel) {
+    return UIPanels.GetValueOrDefault(panel);
+  }
+
+  private static void Register(Panels id, GamePanel panel) {
+    UIPanels.Add(id, panel);
+    panel.ConstructUI();
+  }
+
+  private static void ReportCanvasStateOnce() {
+    if (_reportedCanvasState) return;
+    _reportedCanvasState = true;
+
+    var canvas = _canvasRoot.GetComponent<Canvas>();
+    var rect = _canvasRoot.GetComponent<RectTransform>();
+    var navbar = GetPanel(Panels.Navbar);
+    Plugin.Logger.LogInfo(
+      $"Native uGUI canvas active={_canvasRoot.activeInHierarchy}, enabled={canvas.enabled}, " +
+      $"size={rect.rect.width:F0}x{rect.rect.height:F0}, screen={Screen.width}x{Screen.height}, " +
+      $"navbarActive={navbar?.Enabled ?? false}, childCount={_canvasRoot.transform.childCount}.");
   }
 }

--- a/UI/Widgets/Affix/AffixSection.cs
+++ b/UI/Widgets/Affix/AffixSection.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using daymxn.DHG.ItemSpawner.game;
+using daymxn.DHG.ItemSpawner.ui.Native;
 using UnityEngine;
 using UnityEngine.UI;
-using UniverseLib.UI;
 
 namespace daymxn.DHG.ItemSpawner.ui.Widgets.Affix;
 
@@ -20,7 +21,7 @@ public class AffixSection {
   private readonly GameObject _container;
   private readonly AffixQualityDict _pool;
   private RandomAffix _affix;
-  private Dropdown _affixDropdown;
+  private DropdownBinding<RandomAffix> _affixDropdown;
   private bool _deepChaos;
   private Toggle _deeplyChaosToggle;
 
@@ -30,7 +31,8 @@ public class AffixSection {
   private Quality _parentQuality;
   private Quality _quality;
 
-  private Dropdown _qualityDropdown;
+  private DropdownBinding<Quality> _qualityDropdown;
+  private bool _updatingSlider;
   private float _value;
   private Slider _valueSlider;
   private Text _valueText;
@@ -45,8 +47,15 @@ public class AffixSection {
     _container = container;
     _parentQuality = parentQuality;
     _pool = pool;
-    _quality = parentQuality;
-    _affix = pool[_quality].First();
+    var initial = GameData.Qualities.All
+      .Where(quality => quality <= parentQuality)
+      .LastOrDefault(quality => pool.TryGetValue(quality, out var affixes) && affixes.Count > 0);
+    if (!pool.TryGetValue(initial, out var initialAffixes) || initialAffixes.Count == 0) {
+      throw new InvalidOperationException("The affix pool has no selectable affixes.");
+    }
+
+    _quality = initial;
+    _affix = initialAffixes.First();
   }
 
   /// <summary>
@@ -98,11 +107,11 @@ public class AffixSection {
     var layout = UIFactory.CreateUIObject("Container", _container);
     UIFactory.SetLayoutGroup<HorizontalLayoutGroup>(
       layout,
-      forceHeight: false,
-      forceWidth: false,
-      childControlHeight: true,
-      childControlWidth: true,
-      spacing: 10
+      false,
+      false,
+      true,
+      true,
+      10
     );
 
     var label = UIFactory.CreateLabel(layout, "Title", "Quality");
@@ -115,7 +124,8 @@ public class AffixSection {
       "Quality",
       14,
       OnQualityChanged,
-      []
+      [],
+      _quality
     );
     UIFactory.SetLayoutElement(dropdown, 200, 25, 1);
 
@@ -126,11 +136,11 @@ public class AffixSection {
     var layout = UIFactory.CreateUIObject("Container", _container);
     UIFactory.SetLayoutGroup<HorizontalLayoutGroup>(
       layout,
-      forceHeight: false,
-      forceWidth: false,
-      childControlHeight: true,
-      childControlWidth: true,
-      spacing: 10
+      false,
+      false,
+      true,
+      true,
+      10
     );
 
     var label = UIFactory.CreateLabel(layout, "Title", "Affix");
@@ -143,7 +153,8 @@ public class AffixSection {
       "Affix",
       14,
       OnAffixChanged,
-      []
+      [],
+      _affix
     );
     UIFactory.SetLayoutElement(dropdown, 400, 25, 1);
 
@@ -154,11 +165,11 @@ public class AffixSection {
     var layout = UIFactory.CreateUIObject("Layout", _container);
     UIFactory.SetLayoutGroup<HorizontalLayoutGroup>(
       layout,
-      forceHeight: false,
-      forceWidth: false,
-      childControlHeight: true,
-      childControlWidth: true,
-      spacing: 10
+      false,
+      false,
+      true,
+      true,
+      10
     );
 
     _valueText = UIFactory.CreateLabel(layout, "ValueSlider", "0");
@@ -168,6 +179,7 @@ public class AffixSection {
     UIFactory.SetLayoutElement(slider, 200, 25, 1);
 
     _valueSlider.onValueChanged.AddListener(newValue => {
+      if (_updatingSlider) return;
       _value = newValue;
 
       UpdateSliderValueText();
@@ -195,17 +207,17 @@ public class AffixSection {
     UIFactory.SetLayoutElement(toggle, 20, 20);
   }
 
-  private void OnQualityChanged(int qualityIndex) {
+  private void OnQualityChanged(Quality quality) {
     if (!_drawn) return;
 
-    _quality = GameData.Qualities.FromInt(qualityIndex);
+    _quality = quality;
     UpdateValidAffixes();
   }
 
-  private void OnAffixChanged(int index) {
+  private void OnAffixChanged(RandomAffix affix) {
     if (!_drawn) return;
 
-    _affix = _pool[_quality][index];
+    _affix = affix;
 
     UpdateSliderValues();
   }
@@ -214,14 +226,21 @@ public class AffixSection {
   ///   Updates the quality dropdown options, limited to the parent quality.
   /// </summary>
   private void UpdateValidQualities() {
-    _qualityDropdown.ClearOptions();
+    var validQualities = GameData.Qualities.All
+      .TakeWhile(it => it <= _parentQuality)
+      .Where(quality => _pool.TryGetValue(quality, out var values) && values.Count > 0)
+      .ToList();
+    if (validQualities.Count == 0) {
+      _qualityDropdown.SetOptions([], default);
+      return;
+    }
 
-    var validQualities = GameData.Qualities.All.TakeWhile(it => it <= _parentQuality);
-    _qualityDropdown.AddOptions(
-      validQualities.Select(it => it.GetNameStr()).ToList()
+    if (!validQualities.Contains(_quality)) _quality = validQualities[^1];
+    _qualityDropdown.SetOptions(
+      validQualities.Select(value =>
+        new DropdownOption<Quality>(value.GetNameStr(), value)),
+      _quality
     );
-    _quality = _quality > _parentQuality ? _parentQuality : _quality;
-    _qualityDropdown.SetValueWithoutNotify(_quality.GetValue());
 
     if (!_drawn) return;
     UpdateValidAffixes();
@@ -232,18 +251,18 @@ public class AffixSection {
   ///   the selected quality.
   /// </summary>
   private void UpdateValidAffixes() {
-    _affixDropdown.ClearOptions();
-    var affixes = _pool[_quality];
-    _affixDropdown.AddOptions(
-      affixes
-        .Select(it => it.GetNameStr())
-        .ToList()
-    );
+    if (!_pool.TryGetValue(_quality, out var affixes) || affixes.Count == 0) {
+      _affixDropdown.SetOptions([], null);
+      return;
+    }
 
     // replace affix with the one for this quality, or fallback to the first affix if it doesn't exist in this quality
     // some affixes are quality exclusive
     _affix = affixes.FirstOrDefault(it => it.IsSameTypeAffix(_affix)) ?? affixes.First();
-    _affixDropdown.SetValueWithoutNotify(affixes.IndexOf(_affix));
+    _affixDropdown.SetOptions(
+      CreateAffixOptions(affixes),
+      _affix
+    );
 
     if (!_drawn) return;
     UpdateSliderValues();
@@ -253,9 +272,7 @@ public class AffixSection {
   ///   Updates the slider values to respect the current affix.
   /// </summary>
   private void UpdateSliderValues() {
-    _numType = _affix.IsCompositeAffix()
-      ? AttributeData.NumType.Float
-      : AttributeData.GetAttributeNumType(_affix.GetAttributeName());
+    _numType = GetEffectiveNumType(_affix);
 
     var max = _affix.GetRollMax();
     var min = _affix.GetRollMin();
@@ -265,14 +282,66 @@ public class AffixSection {
       _numType = AttributeData.NumType.Percent;
     }
 
-    _value = Math.Clamp(_value, min, max);
+    _updatingSlider = true;
+    try {
+      // Change integer rounding before assigning a fractional range. Otherwise a
+      // previous integer affix makes ranges such as 0.04-0.05 collapse to 0.
+      _valueSlider.wholeNumbers = _numType == AttributeData.NumType.Int;
+      _valueSlider.minValue = min;
+      _valueSlider.maxValue = max;
 
-    _valueSlider.minValue = min;
-    _valueSlider.maxValue = max;
-    _valueSlider.SetValueWithoutNotify(_value);
-    _valueSlider.wholeNumbers = _numType == AttributeData.NumType.Int;
+      // Configure the complete range before assigning its initial value. Unity's
+      // min/max setters clamp the old value and normally emit onValueChanged.
+      _value = min;
+      _valueSlider.SetValueWithoutNotify(_value);
+    } finally {
+      _updatingSlider = false;
+    }
 
     UpdateSliderValueText();
+  }
+
+  private static AttributeData.NumType GetEffectiveNumType(RandomAffix affix) {
+    // Inc and More are percentage conversions even when the underlying
+    // attribute (maximum mana, maximum life, and similar values) is an integer.
+    if (affix.GetConvertType() != NumConvertType.Add) {
+      return AttributeData.NumType.Percent;
+    }
+
+    return affix.IsCompositeAffix()
+      ? AttributeData.NumType.Float
+      : AttributeData.GetAttributeNumType(affix.GetAttributeName());
+  }
+
+  private static DropdownOption<RandomAffix>[] CreateAffixOptions(
+    IReadOnlyCollection<RandomAffix> affixes
+  ) {
+    var namedAffixes = affixes
+      .Select(affix => (Affix: affix, Name: affix.GetNameStr()))
+      .ToArray();
+    var duplicateNames = namedAffixes
+      .GroupBy(entry => entry.Name)
+      .Where(group => group.Count() > 1)
+      .Select(group => group.Key)
+      .ToHashSet();
+
+    return namedAffixes
+      .Select(entry => new DropdownOption<RandomAffix>(
+        duplicateNames.Contains(entry.Name)
+          ? $"{entry.Name} ({GetConversionLabel(entry.Affix)})"
+          : entry.Name,
+        entry.Affix
+      ))
+      .ToArray();
+  }
+
+  private static string GetConversionLabel(RandomAffix affix) {
+    return affix.GetConvertType() switch {
+      NumConvertType.Add => "Flat",
+      NumConvertType.Inc => "%",
+      NumConvertType.More => "More %",
+      _ => affix.GetConvertType().ToString()
+    };
   }
 
   /// <summary>

--- a/UI/Widgets/ImageSelector/ImageSelector.cs
+++ b/UI/Widgets/ImageSelector/ImageSelector.cs
@@ -1,22 +1,22 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using daymxn.DHG.ItemSpawner.ui.Native;
 using daymxn.DHG.ItemSpawner.ui.Panels;
 using UnityEngine;
 using UnityEngine.UI;
-using UniverseLib.UI;
-using UniverseLib.UI.Models;
 
 namespace daymxn.DHG.ItemSpawner.ui.Widgets.ImageSelector;
 
 /// <summary>
 ///   Helper element for opening an <see cref="ImageSelectorModal" />.
 /// </summary>
-public class ImageSelector {
-  private readonly ButtonRef _button;
+public class ImageSelector<T> {
+  private readonly Button _button;
 
   /// <summary>
   ///   The currently selected image.
   /// </summary>
-  public SelectableImage Selected;
+  public SelectableImage<T> Selected;
 
   /// <summary>
   ///   Creates a UI element for opening an <see cref="ImageSelectorModal" />.
@@ -24,33 +24,45 @@ public class ImageSelector {
   /// <param name="parent">The UI object to attach this element to.</param>
   /// <param name="selectableImages">A list of selectable images to show.</param>
   /// <param name="text">Text to show next to the element, articulating what the selectable is for.</param>
-  public ImageSelector(GameObject parent, List<SelectableImage> selectableImages, string text) {
+  public ImageSelector(
+    GameObject parent,
+    IReadOnlyList<SelectableImage<T>> selectableImages,
+    string text
+  ) {
+    if (selectableImages == null || selectableImages.Count == 0) {
+      throw new ArgumentException("At least one selectable image is required.",
+        nameof(selectableImages));
+    }
+
+    var selectableImages1 = selectableImages;
     Selected = selectableImages[0];
 
     var container = UIFactory.CreateUIObject("ImageSelectorContainer", parent);
     UIFactory.SetLayoutGroup<VerticalLayoutGroup>(
       container,
-      forceHeight: false,
-      forceWidth: false,
-      childControlHeight: true,
-      childControlWidth: true,
-      spacing: 10
+      false,
+      false,
+      true,
+      true,
+      10
     );
 
     var label = UIFactory.CreateLabel(container, "ImageSelectorTitle", text);
     UIFactory.SetLayoutElement(label.gameObject, 75, 25);
 
     _button = UIFactory.CreateButton(container, "OpenImageSelectorButton", "");
-    _button.Component.GetComponent<Image>().sprite = Selected.Image;
-    _button.OnClick += () => {
-      ImageSelectorModal.Instance.Open(Selected, selectableImages, OnImageSelected);
-    };
+    _button.image.sprite = Selected.Image;
+    _button.image.color = Color.white;
+    _button.colors = UIFactory.ColorBlockFor(Color.white);
+    _button.onClick.AddListener(() => {
+      ImageSelectorModal.Instance.Open(Selected, selectableImages1, OnImageSelected);
+    });
 
-    UIFactory.SetLayoutElement(_button.GameObject, 50, 50);
+    UIFactory.SetLayoutElement(_button.gameObject, 50, 50);
   }
 
-  private void OnImageSelected(SelectableImage selectable) {
+  private void OnImageSelected(SelectableImage<T> selectable) {
     Selected = selectable;
-    _button.Component.image.sprite = Selected.Image;
+    _button.image.sprite = Selected.Image;
   }
 }


### PR DESCRIPTION
Completely rewrote the UI system to use Unity's native uGUI instead of `UniverseLib`.

We were running into too many problems with `UniverseLib`, and it hasn't been maintained in a long time anyhow.

This PR also comes with the following fixes:

- You no longer need to bundle `UnityExplorer` (fixes #1)
- The default sizes of windows are inferred from the dimensions of the screen (fixes #2)
- Affixes now internally use the proper value metric; which fixes some % based affixes that weren't working before.
- Dropdowns now close when you click outside of them, or click on their initial value.
- Native search bars in the game are no longer blocked by the mod (this was actually due to a hook from `UniverseLib`).
- Unfinished items are no longer shown in the dropdowns (ie; the ones with no images that were essentially just broken items).
